### PR TITLE
chore(test): Update workflow to use charmcraft latest/edge

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,10 +12,8 @@ jobs:
     secrets: inherit
     with:
       extra-arguments: -x --localstack-address 172.17.0.1
-      charmcraft-repository: alithethird/charmcraft
-      charmcraft-ref: flask-async-worker
       pre-run-script: localstack-installation.sh
-      # charmcraft-channel: latest/edge
+      charmcraft-channel: latest/edge
       modules: '["test_charm.py", "test_cos.py", "test_database.py", "test_db_migration.py", "test_django.py", "test_django_integrations.py", "test_fastapi.py", "test_go.py", "test_integrations.py", "test_proxy.py", "test_workers.py"]'
       rockcraft-channel: latest/edge
       juju-channel: ${{ matrix.juju-version }}


### PR DESCRIPTION
Update integration test workflow to use the charmcraft latest/edge instead of fork.

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../CHANGELOG.md) has been updated

<!-- Explanation for any unchecked items above -->
