### PR TITLE
Chore(refactor): Carry the gunicorn config into jinja template

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ for more!
 
 Additional resources:
 
-* [Tutorial to build a rock for a Flask application](https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/flask/)
+* [Tutorial to build a rock for a Flask application](https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/flask.html)
 * [Charmcraft `flask-framework` reference](https://juju.is/docs/sdk/charmcraft-extension-flask-framework)
 * [Charmcraft `flask-framework` how to guides](https://juju.is/docs/sdk/build-a-paas-charm)
 * [Rockcraft`flask-framework`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,7 @@ commands that need to be run in the root directory of the Flask application:
    rockcraft pack
 
 The `full Rockcraft tutorial
-<https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/flask/>`_ for
+<https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/flask.html>`_ for
 creating an OCI image for a Flask application takes you from a plain Ubuntu
 installation to a production ready OCI image for your Flask application.
 

--- a/examples/fastapi/alembic/versions/eca6177bd16a_initial_migration.py
+++ b/examples/fastapi/alembic/versions/eca6177bd16a_initial_migration.py
@@ -4,7 +4,7 @@
 """Initial migration
 
 Revision ID: eca6177bd16a
-Revises: 
+Revises:
 Create Date: 2023-09-05 17:12:56.303534
 
 """

--- a/examples/flask/test_db_rock/alembic/versions/eca6177bd16a_initial_migration.py
+++ b/examples/flask/test_db_rock/alembic/versions/eca6177bd16a_initial_migration.py
@@ -4,7 +4,7 @@
 """Initial migration
 
 Revision ID: eca6177bd16a
-Revises: 
+Revises:
 Create Date: 2023-09-05 17:12:56.303534
 
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cosl
 jsonschema >=4.23,<4.24
 ops >= 2.6
 pydantic==2.10.6
+Jinja2==3.1.5

--- a/src/paas_charm/_gunicorn/webserver.py
+++ b/src/paas_charm/_gunicorn/webserver.py
@@ -8,10 +8,10 @@ import logging
 import pathlib
 import shlex
 import signal
-import textwrap
 import typing
 from enum import Enum
 
+import jinja2
 import ops
 from ops.pebble import ExecError, PathError
 
@@ -137,7 +137,7 @@ class GunicornWebserver:  # pylint: disable=too-few-public-methods
         Returns:
             The content of the Gunicorn configuration file.
         """
-        config_entries = []
+        config_entries = {}
         for setting, setting_value in self._webserver_config.items():
             setting_value = typing.cast(
                 None | str | WorkerClassEnum | int | datetime.timedelta, setting_value
@@ -146,32 +146,33 @@ class GunicornWebserver:  # pylint: disable=too-few-public-methods
                 continue
             if setting_value is None:
                 continue
-            setting_value = (
+            config_entries[setting] = (
                 setting_value
                 if isinstance(setting_value, (int, str))
                 else int(setting_value.total_seconds())
             )
-            config_entries.append(f"{setting} = {setting_value}")
         if enable_pebble_log_forwarding():
-            access_log = "'-'"
-            error_log = "'-'"
+            access_log = "-"
+            error_log = "-"
         else:
-            access_log = repr(
+            access_log = str(
                 APPLICATION_LOG_FILE_FMT.format(framework=self._workload_config.framework)
             )
-            error_log = repr(
+            error_log = str(
                 APPLICATION_ERROR_LOG_FILE_FMT.format(framework=self._workload_config.framework)
             )
-        config = textwrap.dedent(
-            f"""\
-                bind = ['0.0.0.0:{self._workload_config.port}']
-                chdir = {repr(str(self._workload_config.app_dir))}
-                accesslog = {access_log}
-                errorlog = {error_log}
-                statsd_host = {repr(STATSD_HOST)}
-                """
+
+        jinja_environment = jinja2.Environment(
+            loader=jinja2.PackageLoader("paas_charm", "templates"), autoescape=True
         )
-        config += "\n".join(config_entries)
+        config = jinja_environment.get_template("gunicorn.conf.py.j2").render(
+            workload_port=self._workload_config.port,
+            workload_app_dir=str(self._workload_config.app_dir),
+            access_log=access_log,
+            error_log=error_log,
+            statsd_host=str(STATSD_HOST),
+            config_entries=config_entries,
+        )
         return config
 
     @property

--- a/src/paas_charm/charm_utils.py
+++ b/src/paas_charm/charm_utils.py
@@ -33,7 +33,7 @@ E = typing.TypeVar("E", bound=ops.EventBase)
 
 
 def block_if_invalid_config(
-    method: typing.Callable[[C, E], None]
+    method: typing.Callable[[C, E], None],
 ) -> typing.Callable[[C, E], None]:
     """Create a decorator that puts the charm in blocked state if the config is wrong.
 

--- a/src/paas_charm/templates/gunicorn.conf.py.j2
+++ b/src/paas_charm/templates/gunicorn.conf.py.j2
@@ -1,0 +1,8 @@
+bind = ['0.0.0.0:{{ workload_port }}']
+chdir = '{{ workload_app_dir }}'
+accesslog = '{{ access_log }}'
+errorlog = '{{ error_log }}'
+statsd_host = '{{ statsd_host }}'
+{%- for key, value in config_entries.items() %}
+{{ key }} = {{ value }}
+{%- endfor -%}


### PR DESCRIPTION
Applicable spec: <link>

### Overview
Moved the multiline string `gunicorn.conf.py` template into a jinja template. 
<!-- A high level overview of the change -->

### Rationale
The gunicorn config file was getting more and more complex so it is a good idea to use jinja for the  template. 
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes
`_gunicorn/webserver.py` file has changed to use jinja template.
<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../CHANGELOG.md) has been updated

<!-- Explanation for any unchecked items above -->
