### PR TITLE
Fix/fix missing templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v1.2.1 - 2025-02-07
+
+### Fixed
+
+* Added an init file to fix `missing templates folder` issue in the pypi package.
+
 ## v1.2.0 - 2025-02-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 [project]
 name = "paas-charm"
-version = "1.2.0"
+version = "1.2.1"
 description = "Companion library for 12-factor app support in Charmcraft & Rockcraft."
 readme = "README.md"
 authors = [

--- a/src/paas_charm/templates/__init__.py
+++ b/src/paas_charm/templates/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Templates entrypoint."""


### PR DESCRIPTION

### Overview

Newly add `templates` folder did not have an `__init__.py` file inside. This resulted in that folder not getting included to the pypi package.

### Rationale

Every folder that is required for the package to work should include an `__init__.py` file. 
I add this file into `templates` folder with this pr and incremented the version.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../CHANGELOG.md) has been updated

<!-- Explanation for any unchecked items above -->
