### PR TITLE
change import error logging to be a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v1.2.3 - 2025-02-07
+
+### Changed
+
+* Missing charm libraries at import time are now logged as a warning rather than
+  an exception.
+
 ## v1.2.2 - 2025-02-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 [project]
 name = "paas-charm"
-version = "1.2.2"
+version = "1.2.3"
 description = "Companion library for 12-factor app support in Charmcraft & Rockcraft."
 readme = "README.md"
 authors = [

--- a/src/paas_charm/charm.py
+++ b/src/paas_charm/charm.py
@@ -33,7 +33,7 @@ try:
     # pylint: disable=ungrouped-imports
     from charms.data_platform_libs.v0.s3 import S3Requirer
 except ImportError:
-    logger.exception(
+    logger.warning(
         "Missing charm library, please run `charmcraft fetch-lib charms.data_platform_libs.v0.s3`"
     )
 
@@ -41,7 +41,7 @@ try:
     # pylint: disable=ungrouped-imports
     from charms.saml_integrator.v0.saml import SamlRequires
 except ImportError:
-    logger.exception(
+    logger.warning(
         "Missing charm library, please run `charmcraft fetch-lib charms.saml_integrator.v0.saml`"
     )
 
@@ -49,7 +49,7 @@ try:
     # pylint: disable=ungrouped-imports
     from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer
 except ImportError:
-    logger.exception(
+    logger.warning(
         "Missing charm library, please run "
         "`charmcraft fetch-lib charms.tempo_coordinator_k8s.v0.tracing`"
     )


### PR DESCRIPTION
### Overview

Change the import error handling to log a warning instead of an exception to make it less confusing for users. When it is logged as an exception, a traceback is included and it looks like there is an error when there is no problem.

### Rationale

To make the logs less confusing for users.

### Juju Events Changes

None

### Module Changes

The import handling on the charm module is changed.

### Library Changes

None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../CHANGELOG.md) has been updated

<!-- Explanation for any unchecked items above -->
