### PR TITLE
Add a "Contributing to this documentation" section

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,19 @@ Documentation for this project is located in a few places:
 3. `Charmcraft <https://canonical-charmcraft.readthedocs-hosted.com/en/stable/>`_:
    Documentation related to the software operators (charms)
 
+Contributing to this documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Documentation is an important part of this project, and we take the same open-source
+approach to the documentation as the code. As such, we welcome community contributions,
+suggestions and constructive feedback on our documentation. Our documentation is hosted
+on Read The Docs to enable easy collaboration. Please use the "Edit this page on GitHub"
+or "Give Feedback" links on each documentation page to either directly change something
+you see that's wrong, ask a question, or make a suggestion about a potential change.
+
+If there's a particular area of documentation that you'd like to see that's missing,
+please [file a bug](https://github.com/canonical/paas-charm/issues).
+
 Project and community
 ---------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,7 +77,7 @@ or "Give Feedback" links on each documentation page to either directly change so
 you see that's wrong, ask a question, or make a suggestion about a potential change.
 
 If there's a particular area of documentation that you'd like to see that's missing,
-please [file a bug](https://github.com/canonical/paas-charm/issues).
+please `file a bug <https://github.com/canonical/paas-charm/issues>`_.
 
 Project and community
 ---------------------


### PR DESCRIPTION
Applicable spec: [ISD050](https://docs.google.com/document/d/1Yi3Nvy6b_8YkYx-axbhbhXlowAhgpTnWmvvGoNNaE6Y/edit?tab=t.0)
Applicable Jira ticket: ISD-2666

### Overview

Add a "Contributing to this documentation" section to the RTD home page.

### Rationale

To better align with our community engagement goals for our projects.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The documentation is generated using `src-docs`
- [X] The documentation for RTD is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../CHANGELOG.md) has been updated

<!-- Explanation for any unchecked items above -->
