### PR TITLE
Hide the mantissa for Flask and Django status count and request count dashboard panels

### DIFF
--- a/src/paas_charm/django/cos/grafana_dashboards/django.json
+++ b/src/paas_charm/django/cos/grafana_dashboards/django.json
@@ -33,6 +33,7 @@
       },
       "fieldConfig": {
         "defaults": {
+          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -93,6 +94,7 @@
       },
       "fieldConfig": {
         "defaults": {
+          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -980,6 +982,6 @@
   "timezone": "",
   "title": "Django Operator",
   "uid": null,
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/src/paas_charm/django/cos/grafana_dashboards/django.json
+++ b/src/paas_charm/django/cos/grafana_dashboards/django.json
@@ -814,6 +814,7 @@
         "type": "loki",
         "uid": "${lokids}"
       },
+      "description": "Pick a unit to display logs.",
       "gridPos": {
         "h": 8,
         "w": 24,

--- a/src/paas_charm/flask/cos/grafana_dashboards/flask.json
+++ b/src/paas_charm/flask/cos/grafana_dashboards/flask.json
@@ -33,6 +33,7 @@
       },
       "fieldConfig": {
         "defaults": {
+          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -93,6 +94,7 @@
       },
       "fieldConfig": {
         "defaults": {
+          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -980,6 +982,6 @@
   "timezone": "",
   "title": "Flask Operator",
   "uid": null,
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/src/paas_charm/flask/cos/grafana_dashboards/flask.json
+++ b/src/paas_charm/flask/cos/grafana_dashboards/flask.json
@@ -814,6 +814,7 @@
         "type": "loki",
         "uid": "${lokids}"
       },
+      "description": "Pick a unit to display logs.",
       "gridPos": {
         "h": 8,
         "w": 24,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Hide the mantissa for Flask and Django status count and request count dashboard panels.

### Rationale

This is primarily an aesthetic change.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../CHANGELOG.md) has been updated

<!-- Explanation for any unchecked items above -->
