### PR TITLE
update package version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v1.3.1 - 2025-02-27
+
+### Changed
+
+* Changed workload container name to a constant value for the go-framework
+
 ## v1.3.0 - 2025-02-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* No code changes. [Release workflow from 1.3.1](https://github.com/canonical/paas-charm/actions/runs/13560661165/job/37903076785) seems to have failed due to the error `400 This filename has already been used, use a different version.
-
-## v1.3.1 - 2025-02-27
-
-### Changed
-
 * Changed workload container name to a constant value for the go-framework
 
 ## v1.3.0 - 2025-02-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v1.3.2 - 2025-02-27
+
+### Changed
+
+* No code changes. [Release workflow from 1.3.1](https://github.com/canonical/paas-charm/actions/runs/13560661165/job/37903076785) seems to have failed due to the error `400 This filename has already been used, use a different version.
+
 ## v1.3.1 - 2025-02-27
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 [project]
 name = "paas-charm"
-version = "1.3.0"
+version = "1.3.1"
 description = "Companion library for 12-factor app support in Charmcraft & Rockcraft."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 [project]
 name = "paas-charm"
-version = "1.3.1"
+version = "1.3.2"
 description = "Companion library for 12-factor app support in Charmcraft & Rockcraft."
 readme = "README.md"
 authors = [

--- a/src/paas_charm/go/charm.py
+++ b/src/paas_charm/go/charm.py
@@ -13,6 +13,8 @@ from paas_charm.app import App, WorkloadConfig
 from paas_charm.charm import PaasCharm
 from paas_charm.framework import FrameworkConfig
 
+WORKLOAD_CONTAINER_NAME = "app"
+
 
 class GoConfig(FrameworkConfig):
     """Represent Go builtin configuration values.
@@ -59,7 +61,7 @@ class Charm(PaasCharm):
         framework_config = typing.cast(GoConfig, self.get_framework_config())
         return WorkloadConfig(
             framework=framework_name,
-            container_name="app",
+            container_name=WORKLOAD_CONTAINER_NAME,
             port=framework_config.port,
             base_dir=base_dir,
             app_dir=base_dir,


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
[Release workflow from 1.3.1](https://github.com/canonical/paas-charm/actions/runs/13560661165/job/37903076785) seems to have failed due to the error `400 This filename has already been used, use a different version. Changing the version.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../CHANGELOG.md) has been updated

<!-- Explanation for any unchecked items above -->
