### PR TITLE
Refresh Prometheus scraping info on config-change

### DIFF
--- a/src/paas_charm/observability.py
+++ b/src/paas_charm/observability.py
@@ -48,6 +48,7 @@ class Observability(ops.Object):
             alert_rules_path=os.path.join(cos_dir, "prometheus_alert_rules"),
             jobs=jobs,
             relation_name="metrics-endpoint",
+            refresh_event=[charm.on.config_changed, charm.on[container_name].pebble_ready]
         )
         # The charm isn't necessarily bundled with charms.loki_k8s.v1
         # Dynamically switches between two versions here.

--- a/src/paas_charm/observability.py
+++ b/src/paas_charm/observability.py
@@ -48,7 +48,7 @@ class Observability(ops.Object):
             alert_rules_path=os.path.join(cos_dir, "prometheus_alert_rules"),
             jobs=jobs,
             relation_name="metrics-endpoint",
-            refresh_event=[charm.on.config_changed, charm.on[container_name].pebble_ready]
+            refresh_event=[charm.on.config_changed, charm.on[container_name].pebble_ready],
         )
         # The charm isn't necessarily bundled with charms.loki_k8s.v1
         # Dynamically switches between two versions here.

--- a/tests/integration/go/test_go.py
+++ b/tests/integration/go/test_go.py
@@ -86,6 +86,7 @@ async def test_prometheus_integration(
     config = await go_app.get_config()
     await go_app.set_config({"metrics-port": str(config["metrics-port"]["value"] + 1)})
     await model.wait_for_idle(apps=[go_app.name, prometheus_app.name], status="active")
+    config = await go_app.get_config()
 
     for unit_ip in await get_unit_ips(prometheus_app.name):
         query_targets = requests.get(f"http://{unit_ip}:9090/api/v1/targets", timeout=10).json()

--- a/tests/integration/go/test_go.py
+++ b/tests/integration/go/test_go.py
@@ -84,7 +84,7 @@ async def test_prometheus_integration(
     await model.wait_for_idle(apps=[go_app.name, prometheus_app.name], status="active")
 
     config = await go_app.get_config()
-    await go_app.set_config({"metrics-port": config["metrics-port"]["value"] + 1})
+    await go_app.set_config({"metrics-port": str(config["metrics-port"]["value"] + 1)})
     await model.wait_for_idle(apps=[go_app.name, prometheus_app.name], status="active")
 
     for unit_ip in await get_unit_ips(prometheus_app.name):

--- a/tests/integration/go/test_go.py
+++ b/tests/integration/go/test_go.py
@@ -84,6 +84,9 @@ async def test_prometheus_integration(
     await model.wait_for_idle(apps=[go_app.name, prometheus_app.name], status="active")
 
     config = await go_app.get_config()
+    await go_app.set_config({"metrics-port": config["metrics-port"]["value"] + 1})
+    await model.wait_for_idle(apps=[go_app.name, prometheus_app.name], status="active")
+
     for unit_ip in await get_unit_ips(prometheus_app.name):
         query_targets = requests.get(f"http://{unit_ip}:9090/api/v1/targets", timeout=10).json()
         active_targets = query_targets["data"]["activeTargets"]


### PR DESCRIPTION
Applicable spec: <link>

### Overview

By default, the `MetricsEndpointProvider` only refreshes the Prometheus scraping information inside the integration data on the [`relation-joined` and `pebble-ready` events](https://github.com/canonical/prometheus-k8s-operator/blob/e09913477484f9ca006171ed949a9702bec3251e/lib/charms/prometheus_k8s/v0/prometheus_scrape.py#L1469-L1497). This is problematic for Go applications, as the metrics endpoint and port are set inside the charm configuration. In this pull request, update `Observability` class to refresh the Prometheus scraping information during the `config-changed` event as well to fix this issue.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../CHANGELOG.md) has been updated

<!-- Explanation for any unchecked items above -->
