### PR TITLE
Add event handler for secret_storage_relation_departed hook

### DIFF
--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -34,7 +34,6 @@ jobs:
             cargo \
             libpython3-dev \
             libxml2-dev \
-            libxslt1-dev \
             make \
             python3-venv \
             rustc \

--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -30,10 +30,11 @@ jobs:
       - name: Install dependencies
         run: |
           set -ex
-          sudo apt -y install \
+          sudo apt update && sudo apt -y install \
             cargo \
             libpython3-dev \
             libxml2-dev \
+            libxslt1-dev \
             make \
             python3-venv \
             rustc \

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## v1.4.1 - 2025-03.25
+
+* fix: Added event handler for `secret_storage_relation_changed` event.
+
 ## v1.4.0 - 2025-03-04
 
 * feat: Added support for smtp integration.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,8 @@ Place any unreleased changes here, that are subject to release in coming version
 
 ## v1.4.1 - 2025-03.25
 
-* fix: Added event handler for `secret_storage_relation_changed` event.
+* fix: Added event handler for `secret_storage_relation_changed` 
+  event.
 
 ## v1.4.0 - 2025-03-04
 

--- a/docs/explanation/charm-architecture.rst
+++ b/docs/explanation/charm-architecture.rst
@@ -127,7 +127,7 @@ For a web app charm, the following events are observed:
 
 25. `smtp_data_available <https://github.com/canonical/smtp-integrator-operator>`_: fired when new SMTP data is present in the relation. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-26. `rotate_secret_key <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#action-hooks>`_: fired when rotate-secret-key is executed.  **Action**: generate a new secret token for the application.
+26. `rotate_secret_key <https://documentation.ubuntu.com/juju/latest/user/reference/action/>`_: fired when secret-rotate is executed.  **Action**: generate a new secret token for the application.
 
 Charm code overview
 -------------------

--- a/docs/explanation/charm-architecture.rst
+++ b/docs/explanation/charm-architecture.rst
@@ -81,51 +81,53 @@ For a web app charm, the following events are observed:
 
 2. `config_changed <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#config-changed>`_: usually fired in response to a configuration change using the CLI. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-3. `secret_storage_relation_created <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-changed>`_: fired when the relation is first created. **Action**: generate a new secret and store it in the relation data.
+3. `secret_storage_relation_created <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-created>`_: fired when the relation is first created. **Action**: generate a new secret and store it in the relation data.
 
 4. `secret_storage_relation_changed <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-changed>`_: fired when a new unit joins in an existing relation and whenever the related unit changes its settings. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-5. `update_status <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#update-status>`_: fired at regular intervals. **Action**: validate the configuration, run pending migrations and restart the workload.
+5. `secret_storage_relation_departed <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-departed>`_: fired when a unit departs from an existing relation. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-6. `secret_changed <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#secret-changed>`_: fired when the secret owner publishes a new secret revision. **Action**: validate the configuration, run pending migrations and restart the workload.
+6. `update_status <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#update-status>`_: fired at regular intervals. **Action**: validate the configuration, run pending migrations and restart the workload.
 
-7. `database_created <https://github.com/canonical/data-platform-libs>`_: fired when a new database is created. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+7. `secret_changed <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#secret-changed>`_: fired when the secret owner publishes a new secret revision. **Action**: validate the configuration, run pending migrations and restart the workload.
 
-8. `endpoints_changed <https://github.com/canonical/data-platform-libs>`_: fired when the database endpoints change. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+8. `database_created <https://github.com/canonical/data-platform-libs>`_: fired when a new database is created. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-9. `database_relation_broken <https://github.com/canonical/data-platform-libs>`_: fired when a unit participating in a non-peer relation is removed. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+9. `endpoints_changed <https://github.com/canonical/data-platform-libs>`_: fired when the database endpoints change. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-10. `ingress_ready <https://github.com/canonical/traefik-k8s-operator>`_: fired when the ingress for the web app is ready. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+10. `database_relation_broken <https://github.com/canonical/data-platform-libs>`_: fired when a unit participating in a non-peer relation is removed. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-11. `ingress_revoked <https://github.com/canonical/traefik-k8s-operator>`_: fired when the ingress for the web app is not ready anymore. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+11. `ingress_ready <https://github.com/canonical/traefik-k8s-operator>`_: fired when the ingress for the web app is ready. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-12. `redis_relation_updated <https://github.com/canonical/redis-k8s-operator>`_:  fired when a new unit joins in an existing relation and whenever the related unit changes its settings. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+12. `ingress_revoked <https://github.com/canonical/traefik-k8s-operator>`_: fired when the ingress for the web app is not ready anymore. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-13. `s3_credentials_changed <https://github.com/canonical/data-platform-libs>`_: fired when the S3 credentials are changed. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+13. `redis_relation_updated <https://github.com/canonical/redis-k8s-operator>`_:  fired when a new unit joins in an existing relation and whenever the related unit changes its settings. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-14. `s3_credentials_gone <https://github.com/canonical/data-platform-libs>`_: fired when the S3 credentials are removed. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+14. `s3_credentials_changed <https://github.com/canonical/data-platform-libs>`_: fired when the S3 credentials are changed. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-15. `saml_data_available <https://github.com/canonical/saml-integrator-operator>`_: fired when new SAML data is present in the relation. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+15. `s3_credentials_gone <https://github.com/canonical/data-platform-libs>`_: fired when the S3 credentials are removed. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-16. `rabbitmq_ready <https://github.com/openstack-charmers/charm-rabbitmq-k8s>`_: fired after a ``rabbitmq_cjoined`` event. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+16. `saml_data_available <https://github.com/canonical/saml-integrator-operator>`_: fired when new SAML data is present in the relation. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-17. `rabbitmq_connected <https://github.com/openstack-charmers/charm-rabbitmq-k8s>`_: fired after a ``rabbitmq_changed`` or ``rabbitmq_broken`` event. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+17. `rabbitmq_ready <https://github.com/openstack-charmers/charm-rabbitmq-k8s>`_: fired after a ``rabbitmq_cjoined`` event. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-18. `rabbitmq_joined <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-joined>`_: fired when a new unit joins in an existing relation. **Action**: request access to the RabbitMQ server and emit a connected event.
+18. `rabbitmq_connected <https://github.com/openstack-charmers/charm-rabbitmq-k8s>`_: fired after a ``rabbitmq_changed`` or ``rabbitmq_broken`` event. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-19. `rabbitmq_changed <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-changed>`_: fired when a new unit joins in an existing relation and whenever the related unit changes its settings. **Action**: request access to the RabbitMQ server and emit a ready event.
+19. `rabbitmq_joined <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-joined>`_: fired when a new unit joins in an existing relation. **Action**: request access to the RabbitMQ server and emit a connected event.
 
-20. `rabbitmq_broken <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-broken>`_: fired when a unit participating in a non-peer relation is removed. **Action**: emit a ready event.
+20. `rabbitmq_changed <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-changed>`_: fired when a new unit joins in an existing relation and whenever the related unit changes its settings. **Action**: request access to the RabbitMQ server and emit a ready event.
 
-21. `rabbitmq_departed <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-departed>`_: fired when a related unit is no longer related. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+21. `rabbitmq_broken <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-broken>`_: fired when a unit participating in a non-peer relation is removed. **Action**: emit a ready event.
 
-22. `tracing_endpoint_changed <https://github.com/canonical/tempo-coordinator-k8s-operator>`_: fired when one of the receiver endpoints changes. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+22. `rabbitmq_departed <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#endpoint-relation-departed>`_: fired when a related unit is no longer related. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-23. `tracing_endpoint_removed <https://github.com/canonical/tempo-coordinator-k8s-operator>`_: fired when one of the receiver endpoints is removed. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+23. `tracing_endpoint_changed <https://github.com/canonical/tempo-coordinator-k8s-operator>`_: fired when one of the receiver endpoints changes. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-24. `smtp_data_available <https://github.com/canonical/smtp-integrator-operator>`_: fired when new SMTP data is present in the relation. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+24. `tracing_endpoint_removed <https://github.com/canonical/tempo-coordinator-k8s-operator>`_: fired when one of the receiver endpoints is removed. **Action**: validate the charm configuration, run pending migrations and restart the workload.
 
-25. `rotate_secret_key <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#action-hooks>`_: fired when rotate-secret-key is executed.  **Action**: generate a new secret token for the application.
+25. `smtp_data_available <https://github.com/canonical/smtp-integrator-operator>`_: fired when new SMTP data is present in the relation. **Action**: validate the charm configuration, run pending migrations and restart the workload.
+
+26. `rotate_secret_key <https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/hook/#action-hooks>`_: fired when rotate-secret-key is executed.  **Action**: generate a new secret token for the application.
 
 Charm code overview
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 [project]
 name = "paas-charm"
-version = "1.4.0"
+version = "1.4.1"
 description = "Companion library for 12-factor app support in Charmcraft & Rockcraft."
 readme = "README.md"
 authors = [

--- a/src/paas_charm/charm.py
+++ b/src/paas_charm/charm.py
@@ -366,7 +366,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
 
     @block_if_invalid_config
     def _on_secret_storage_relation_departed(self, _: ops.HookEvent) -> None:
-        """Handle the secret-storage-relation-departed event"""
+        """Handle the secret-storage-relation-departed event."""
         self.restart()
 
     def update_app_and_unit_status(self, status: ops.StatusBase) -> None:

--- a/src/paas_charm/charm.py
+++ b/src/paas_charm/charm.py
@@ -136,6 +136,10 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
             self.on.secret_storage_relation_changed,
             self._on_secret_storage_relation_changed,
         )
+        self.framework.observe(
+            self.on.secret_storage_relation_departed,
+            self._on_secret_storage_relation_departed,
+        )
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.secret_changed, self._on_secret_changed)
         for database, database_requirer in self._database_requirers.items():
@@ -358,6 +362,11 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
     @block_if_invalid_config
     def _on_secret_storage_relation_changed(self, _: ops.RelationEvent) -> None:
         """Handle the secret-storage-relation-changed event."""
+        self.restart()
+
+    @block_if_invalid_config
+    def _on_secret_storage_relation_departed(self, _: ops.HookEvent) -> None:
+        """Handle the secret-storage-relation-departed event"""
         self.restart()
 
     def update_app_and_unit_status(self, status: ops.StatusBase) -> None:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
- Added an event handler for  the`secret_storage_relation_departed` hook. Action: App restarts on the `secret_storage_relation_departed` event.
- Added a unit test that checks if the restart function is called when the secret_storage_relation_departed hook is triggered.

### Rationale

<!-- The reason the change is needed -->
When paas-charm applications scale down in the number of units, nothing happens since the associated hook is not handled by paas-charm.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
Newly added events - `secret_storage_relation_departed`

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
