### PR TITLE
Chore: Refactor

### DIFF
--- a/src/paas_charm/charm.py
+++ b/src/paas_charm/charm.py
@@ -331,7 +331,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
         Returns:
             Return the directory with COS related files.
         """
-        return str((pathlib.Path(__file__).parent / "cos").absolute())
+        return str((pathlib.Path(__file__).parent / f"{self._framework_name}/cos").absolute())
 
     @property
     def _container(self) -> Container:

--- a/src/paas_charm/charm.py
+++ b/src/paas_charm/charm.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 """The base charm class for all application charms."""
-
 import abc
 import logging
 import pathlib

--- a/src/paas_charm/django/charm.py
+++ b/src/paas_charm/django/charm.py
@@ -2,8 +2,8 @@
 # See LICENSE file for licensing details.
 
 """Django Charm service."""
+
 import logging
-import pathlib
 import secrets
 import typing
 from urllib.parse import urlsplit
@@ -67,14 +67,6 @@ class Charm(GunicornBase):
         """
         super().__init__(framework=framework, framework_name="django")
         self.framework.observe(self.on.create_superuser_action, self._on_create_superuser_action)
-
-    def get_cos_dir(self) -> str:
-        """Return the directory with COS related files.
-
-        Returns:
-            Return the directory with COS related files.
-        """
-        return str((pathlib.Path(__file__).parent / "cos").absolute())
 
     def get_framework_config(self) -> BaseModel:
         """Return the framework related configurations.

--- a/src/paas_charm/django/charm.py
+++ b/src/paas_charm/django/charm.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 """Django Charm service."""
-
 import logging
 import secrets
 import typing

--- a/src/paas_charm/fastapi/charm.py
+++ b/src/paas_charm/fastapi/charm.py
@@ -79,17 +79,6 @@ class Charm(PaasCharm):
             unit_name=self.unit.name,
         )
 
-    def get_cos_dir(self) -> str:
-        """Return the directory with COS related files.
-
-        Returns:
-            Return the directory with COS related files.
-        """
-        # __file__ is different depending on the file, so moving this method
-        # to the superclass will not work correctly.
-        # pylint: disable=R0801
-        return str((pathlib.Path(__file__).parent / "cos").absolute())
-
     def _create_app(self) -> App:
         """Build a App instance.
 

--- a/src/paas_charm/flask/charm.py
+++ b/src/paas_charm/flask/charm.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 """Flask Charm service."""
-
 import logging
 
 import ops

--- a/src/paas_charm/flask/charm.py
+++ b/src/paas_charm/flask/charm.py
@@ -2,8 +2,8 @@
 # See LICENSE file for licensing details.
 
 """Flask Charm service."""
+
 import logging
-import pathlib
 
 import ops
 from pydantic import ConfigDict, Field, field_validator
@@ -77,11 +77,3 @@ class Charm(GunicornBase):
             framework: operator framework.
         """
         super().__init__(framework=framework, framework_name="flask")
-
-    def get_cos_dir(self) -> str:
-        """Return the directory with COS related files.
-
-        Returns:
-            Return the directory with COS related files.
-        """
-        return str((pathlib.Path(__file__).parent / "cos").absolute())

--- a/src/paas_charm/go/charm.py
+++ b/src/paas_charm/go/charm.py
@@ -58,6 +58,7 @@ class Charm(PaasCharm):
         """Return an WorkloadConfig instance."""
         framework_name = self._framework_name
         base_dir = pathlib.Path("/app")
+        state_dir = base_dir / "state"
         framework_config = typing.cast(GoConfig, self.get_framework_config())
         return WorkloadConfig(
             framework=framework_name,
@@ -65,21 +66,13 @@ class Charm(PaasCharm):
             port=framework_config.port,
             base_dir=base_dir,
             app_dir=base_dir,
-            state_dir=base_dir / "state",
+            state_dir=state_dir,
             service_name=framework_name,
             log_files=[],
+            unit_name=self.unit.name,
             metrics_target=f"*:{framework_config.metrics_port}",
             metrics_path=framework_config.metrics_path,
-            unit_name=self.unit.name,
         )
-
-    def get_cos_dir(self) -> str:
-        """Return the directory with COS related files.
-
-        Returns:
-            Return the directory with COS related files.
-        """
-        return str((pathlib.Path(__file__).parent / "cos").absolute())
 
     def _create_app(self) -> App:
         """Build a App instance.


### PR DESCRIPTION

### Overview

We set the `get_cos_dir` function as an abstract function and let all the frameworks to define it for themselves but they define it in the exact same way. This leads to code duplication.

### Module Changes

Removed `get_cos_dir` function from individual framework charm classes and defined it in the `PaasCharm` class.
<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
