### PR TITLE
Chore: Remove old juju versions

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,7 +7,7 @@ jobs:
   integration-tests:
     strategy:
       matrix:
-        juju-version: [ 3.3/stable, 3.4/stable, 3.5/stable, 3.6/stable ]
+        juju-version: [ 3.6/stable ]
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cosl
-Jinja2==3.1.6
+Jinja2 == 3.1.6
 jsonschema >=4.23,<4.24
-ops>= 2.6
-pydantic==2.10.6
+ops >= 2.6
+pydantic == 2.10.6

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -717,23 +717,3 @@ def run_action(ops_test: OpsTest):
         return action.results
 
     return _run_action
-
-
-@pytest.fixture(autouse=True)
-def skip_by_juju_version(request, model):
-    """Skip the test if juju version is lower then the `skip_juju_version` marker value."""
-    if request.node.get_closest_marker("skip_juju_version"):
-        current_version = JujuVersion(
-            f"{model.info.agent_version.major}.{model.info.agent_version.minor}.{model.info.agent_version.patch}"
-        )
-        min_version = JujuVersion(request.node.get_closest_marker("skip_juju_version").args[0])
-        if current_version < min_version:
-            pytest.skip("Juju version is too old")
-
-
-def pytest_configure(config):
-    """Add new marker."""
-    config.addinivalue_line(
-        "markers",
-        "skip_juju_version(version): skip test if Juju version is lower than version",
-    )

--- a/tests/integration/flask/test_cos.py
+++ b/tests/integration/flask/test_cos.py
@@ -7,7 +7,6 @@ import asyncio
 import logging
 import typing
 
-import juju.client.client
 import juju.model
 import requests
 from juju.application import Application
@@ -71,10 +70,7 @@ async def test_loki_integration(
     log = result[-1]
     logging.info("retrieve sample application log: %s", log)
     assert any("python-requests" in line[1] for line in log["values"])
-    if model.info.agent_version < juju.client.client.Number.from_json("3.4.0"):
-        assert "filename" in log["stream"]
-    else:
-        assert "filename" not in log["stream"]
+    assert "filename" not in log["stream"]
 
 
 async def test_grafana_integration(

--- a/tests/integration/general/test_non_root_db_migration.py
+++ b/tests/integration/general/test_non_root_db_migration.py
@@ -6,12 +6,10 @@
 
 import logging
 
-import juju.client.client
 import juju.model
 import pytest
 import requests
 from juju.application import Application
-from juju.errors import JujuError
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +41,6 @@ logger = logging.getLogger(__name__)
         ),
     ],
 )
-@pytest.mark.skip_juju_version("3.6")  # Only Juju>=3.6 supports non-root users
 async def test_non_root_db_migration(
     non_root_app_fixture: str,
     app_name: str,

--- a/tests/integration/general/test_non_root_loki.py
+++ b/tests/integration/general/test_non_root_loki.py
@@ -8,7 +8,6 @@ import asyncio
 import logging
 import typing
 
-import juju.client.client
 import juju.model
 import pytest
 import requests
@@ -26,7 +25,6 @@ logger = logging.getLogger(__name__)
         pytest.param("go_non_root_app", 8080, id="Go non-root"),
     ],
 )
-@pytest.mark.skip_juju_version("3.6")  # Only Juju>=3.6 supports non-root users
 async def test_non_root_loki_integration(
     model: juju.model.Model,
     loki_app_name: str,
@@ -64,7 +62,4 @@ async def test_non_root_loki_integration(
     log = result[-1]
     logging.info("retrieve sample application log: %s", log)
     assert log["values"]  # any("python-requests" in line[1] for line in log["values"])
-    if model.info.agent_version < juju.client.client.Number.from_json("3.4.0"):
-        assert "filename" in log["stream"]
-    else:
-        assert "filename" not in log["stream"]
+    assert "filename" not in log["stream"]

--- a/tests/integration/integrations/test_tracing.py
+++ b/tests/integration/integrations/test_tracing.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
         ("go_app", 8080),
     ],
 )
-@pytest.mark.skip_juju_version("3.4")  # Tempo only supports Juju>=3.4
 async def test_workload_tracing(
     ops_test: OpsTest,
     model: Model,

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,10 +1,10 @@
+aiohttp == 3.11.7
+boto3 == 1.38.12
+cosl == 0.1.0
+git+https://github.com/canonical/saml-test-idp.git
+juju == 3.5.2.1
+minio == 7.2.14
+nest_asyncio == 1.6.0
 ops >= 1.5.0
 pytest-operator >= 0.32.0
-aiohttp == 3.11.7
 tenacity == 9.0.0
-nest_asyncio == 1.6.0
-minio == 7.2.14
-cosl
-boto3
-juju==3.5.2.1
-git+https://github.com/canonical/saml-test-idp.git

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -4,3 +4,7 @@ aiohttp == 3.11.7
 tenacity == 9.0.0
 nest_asyncio == 1.6.0
 minio == 7.2.14
+cosl
+boto3
+juju==3.5.2.1
+git+https://github.com/canonical/saml-test-idp.git

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,3 +1,3 @@
-cosl
-pytest
+cosl == 0.1.0
 coverage[toml]
+pytest

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,3 @@
+cosl
+pytest
+coverage[toml]

--- a/tox.ini
+++ b/tox.ini
@@ -90,10 +90,8 @@ commands =
 [testenv:unit]
 description = Run unit tests
 deps =
-    cosl
-    pytest
-    coverage[toml]
     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/tests/unit/requirements.txt
 commands =
     coverage run --source={[vars]src_path},{[vars]legacy_src_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
@@ -111,10 +109,6 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    cosl
-    boto3
-    juju==3.5.2.1
-    git+https://github.com/canonical/saml-test-idp.git
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/tests/integration/requirements.txt
 commands =


### PR DESCRIPTION
Applicable spec: ISD-3383

### Overview

Removing EOL Juju versions from integration tests.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
