### PR TITLE
chore: refactor smtp env mapper

### DIFF
--- a/src/paas_charm/app.py
+++ b/src/paas_charm/app.py
@@ -216,10 +216,16 @@ def generate_smtp_env(relation_data: "SmtpRelationData | None" = None) -> dict[s
     return {
         k: v
         for k, v in (
-            ("OTEL_SERVICE_NAME", relation_data.service_name),
-            ("OTEL_EXPORTER_OTLP_ENDPOINT", str(relation_data.endpoint)),
+            ("SMTP_HOST", relation_data.host),
+            ("SMTP_PORT", str(relation_data.port)),
+            ("SMTP_USER", relation_data.user),
+            ("SMTP_PASSWORD", relation_data.password),
+            ("SMTP_AUTH_TYPE", relation_data.auth_type.value),
+            ("SMTP_TRANSPORT_SECURITY", relation_data.transport_security.value),
+            ("SMTP_DOMAIN", relation_data.domain),
+            ("SMTP_SKIP_SSL_VERIFY", str(relation_data.skip_ssl_verify)),
         )
-        if v is not None
+        if v is not None and v not in ("none")
     }
 
 
@@ -238,16 +244,10 @@ def generate_tempo_env(relation_data: "PaaSTempoRelationData | None" = None) -> 
     return {
         k: v
         for k, v in (
-            ("SMTP_HOST", relation_data.host),
-            ("SMTP_PORT", str(relation_data.port)),
-            ("SMTP_USER", relation_data.user),
-            ("SMTP_PASSWORD", relation_data.password),
-            ("SMTP_AUTH_TYPE", relation_data.auth_type.value),
-            ("SMTP_TRANSPORT_SECURITY", relation_data.transport_security.value),
-            ("SMTP_DOMAIN", relation_data.domain),
-            ("SMTP_SKIP_SSL_VERIFY", str(relation_data.skip_ssl_verify)),
+            ("OTEL_SERVICE_NAME", relation_data.service_name),
+            ("OTEL_EXPORTER_OTLP_ENDPOINT", str(relation_data.endpoint)),
         )
-        if v is not None and v not in ("none")
+        if v is not None
     }
 
 

--- a/src/paas_charm/app.py
+++ b/src/paas_charm/app.py
@@ -163,14 +163,14 @@ def generate_saml_env(relation_data: "PaaSSAMLRelationData | None" = None) -> di
     }
 
 
-def generate_stmp_env(relation_data: "SmtpRelationData | None" = None) -> dict[str, str]:
-    """Generate environment variable from SAML relation data.
+def generate_smtp_env(relation_data: "SmtpRelationData | None" = None) -> dict[str, str]:
+    """Generate environment variable from SMTP relation data.
 
     Args:
-        relation_data: The charm SAML integration relation data.
+        relation_data: The charm SMTP integration relation data.
 
     Returns:
-        SAML environment mappings if SAML relation data is available, empty
+        SMTP environment mappings if SMTP relation data is available, empty
         dictionary otherwise.
     """
     if not relation_data:
@@ -200,13 +200,13 @@ class App:  # pylint: disable=too-many-instance-attributes
         generate_rabbitmq_env: Maps RabbitMQ connection information to environment variables.
         generate_s3_env: Maps S3 connection information to environment variables.
         generate_saml_env: Maps SAML connection information to environment variables.
-        generate_stmp_env: Maps STMP connection information to environment variables.
+        generate_smtp_env: Maps STMP connection information to environment variables.
     """
 
     generate_rabbitmq_env = staticmethod(generate_rabbitmq_env)
     generate_s3_env = staticmethod(generate_s3_env)
     generate_saml_env = staticmethod(generate_saml_env)
-    generate_stmp_env = staticmethod(generate_stmp_env)
+    generate_smtp_env = staticmethod(generate_smtp_env)
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -317,7 +317,7 @@ class App:  # pylint: disable=too-many-instance-attributes
         )
         env.update(self.generate_s3_env(relation_data=self._charm_state.integrations.s3))
         env.update(self.generate_saml_env(relation_data=self._charm_state.integrations.saml))
-        env.update(self.generate_stmp_env(relation_data=self._charm_state.integrations.smtp))
+        env.update(self.generate_smtp_env(relation_data=self._charm_state.integrations.smtp))
         return env
 
     @property

--- a/src/paas_charm/charm.py
+++ b/src/paas_charm/charm.py
@@ -515,7 +515,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
             if not requires["tracing"].optional:
                 yield "tracing"
 
-        if self._smtp and not charm_state.integrations.smtp_parameters:
+        if self._smtp and not charm_state.integrations.smtp:
             if not requires["smtp"].optional:
                 yield "smtp"
 

--- a/src/paas_charm/charm_state.py
+++ b/src/paas_charm/charm_state.py
@@ -370,7 +370,7 @@ class IntegrationsState:  # pylint: disable=too-many-instance-attributes
         saml_relation_data: "PaaSSAMLRelationData| None" = None,
         rabbitmq_relation_data: "PaaSRabbitMQRelationData | None" = None,
         tempo_relation_data: "PaaSTempoRelationData | None" = None,
-        smtp_relation_data: SmtpRelationData | None = None,
+        smtp_relation_data: "SmtpRelationData | None" = None,
         openfga_relation_data: dict | None = None,
     ) -> "IntegrationsState":
         """Initialize a new instance of the IntegrationsState class.

--- a/src/paas_charm/charm_state.py
+++ b/src/paas_charm/charm_state.py
@@ -65,7 +65,7 @@ try:
     # the import is used for type hinting
     # pylint: disable=ungrouped-imports
     # pylint: disable=unused-import
-    from charms.smtp_integrator.v0.smtp import SmtpRequires
+    from charms.smtp_integrator.v0.smtp import SmtpRelationData, SmtpRequires
 except ImportError:
     # we already logged it in charm.py
     pass
@@ -198,7 +198,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
                 ),
                 tracing_requirer=integration_requirers.tracing,
                 smtp_relation_data=(
-                    smtp_data.to_relation_data()
+                    smtp_data
                     if (
                         integration_requirers.smtp
                         and (smtp_data := integration_requirers.smtp.get_relation_data())
@@ -338,7 +338,7 @@ class IntegrationsState:  # pylint: disable=too-many-instance-attributes
         saml: SAML parameters.
         rabbitmq_uri: RabbitMQ uri.
         tempo_parameters: Tracing parameters.
-        smtp_parameters: Smtp parameters.
+        smtp: Smtp parameters.
         openfga_parameters: OpenFGA parameters.
     """
 
@@ -348,7 +348,7 @@ class IntegrationsState:  # pylint: disable=too-many-instance-attributes
     saml: "PaaSSAMLRelationData | None" = None
     rabbitmq_uri: str | None = None
     tempo_parameters: "TempoParameters | None" = None
-    smtp_parameters: "SmtpParameters | None" = None
+    smtp: "SmtpRelationData | None" = None
     openfga_parameters: "OpenfgaParameters | None" = None
 
     # This dataclass combines all the integrations, so it is reasonable that they stay together.
@@ -363,7 +363,7 @@ class IntegrationsState:  # pylint: disable=too-many-instance-attributes
         rabbitmq_uri: str | None = None,
         tracing_requirer: "TracingEndpointRequirer | None" = None,
         app_name: str | None = None,
-        smtp_relation_data: dict | None = None,
+        smtp_relation_data: SmtpRelationData | None = None,
         openfga_relation_data: dict | None = None,
     ) -> "IntegrationsState":
         """Initialize a new instance of the IntegrationsState class.
@@ -389,7 +389,6 @@ class IntegrationsState:  # pylint: disable=too-many-instance-attributes
                 "endpoint": tracing_requirer.get_endpoint(protocol="otlp_http"),
             }
         tempo_parameters = generate_relation_parameters(tempo_data, TempoParameters)
-        smtp_parameters = generate_relation_parameters(smtp_relation_data, SmtpParameters)
         openfga_parameters = generate_relation_parameters(openfga_relation_data, OpenfgaParameters)
 
         # Workaround as the Redis library temporarily sends the port
@@ -408,7 +407,7 @@ class IntegrationsState:  # pylint: disable=too-many-instance-attributes
             saml=saml_relation_data,
             rabbitmq_uri=rabbitmq_uri,
             tempo_parameters=tempo_parameters,
-            smtp_parameters=smtp_parameters,
+            smtp=smtp_relation_data,
             openfga_parameters=openfga_parameters,
         )
 

--- a/tests/unit/general/test_integrations.py
+++ b/tests/unit/general/test_integrations.py
@@ -235,11 +235,6 @@ def _test_integrations_state_build_parameters():
             id="Smtp empty parameters",
         ),
         pytest.param(
-            {**relation_dict, "smtp_relation_data": {"wrong_key": "wrong_value"}},
-            True,
-            id="Smtp wrong parameters",
-        ),
-        pytest.param(
             {
                 **relation_dict,
                 "rabbitmq_uri": "amqp://test-app:3m036hhyiDHs@rabbitmq-k8s-endpoints.testing.svc.cluster.local:5672/",


### PR DESCRIPTION
Applicable spec: N/A

### Overview

1. Refactor SMTP Parameters to use SMTP relation data directly
2. Introduce SMTP environment variable mapper

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
No user relevant changes