### PR TITLE
Chore: Use latest edge rocckraft

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -14,9 +14,7 @@ jobs:
       extra-arguments: '-x --log-format="%(asctime)s %(levelname)s %(message)s"'
       charmcraft-channel: latest/edge
       modules: '["test_charm.py", "test_config.py", "test_database.py", "test_db_migration.py", "test_django.py", "test_django_integrations.py", "test_fastapi.py", "test_go.py", "test_grafana.py", "test_integrations.py", "test_loki.py", "test_minimal.py", "test_non_root_db_migration.py", "test_non_root_loki.py", "test_openfga.py", "test_prometheus.py", "test_proxy.py", "test_s3.py", "test_saml.py", "test_smtp.py", "test_tracing.py", "test_workers.py"]'
-      # rockcraft-channel: latest/edge
-      rockcraft-repository: canonical/rockcraft
-      rockcraft-ref: main
+      rockcraft-channel: latest/edge
       juju-channel: ${{ matrix.juju-version }}
       channel: 1.29-strict/stable
       test-timeout: 45


### PR DESCRIPTION
### Overview

Our latest features (non-root charm) are all in the latest/edge channel of rockcraft.
We should not keep building the rockcraft snap because it doesn't have advantages anymore.
It slows down the CI to build it from source.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
