### PR TITLE
Refactor RTD home page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## 1.7.1 - 2025-06-16
+
+* docs: Refactored the RTD home page. Moved content into Explanation.
+
 ## 1.7.1 - 2025-06-12
 
 * docs: Added an edit button to the RTD project.

--- a/docs/explanation/foundations.rst
+++ b/docs/explanation/foundations.rst
@@ -17,11 +17,10 @@ following Canonical products:
   tool to create rocks – a new generation of secure, stable and OCI-compliant
   container images, based on Ubuntu.
 
-A Rockcraft framework (conceptually similar to a `snap
-extension <https://snapcraft.io/docs/snapcraft-extensions>`_) is initially
-used to facilitate the creation of a well structured, minimal and hardened
-container image, called a rock. A Charmcraft profile can then be leveraged to
-add a software operator (charm) around the aforementioned container image.
+A Rockcraft framework is initially used to facilitate the creation of a well
+structured, minimal and hardened container image, called a rock. A Charmcraft
+profile can then be leveraged to add a software operator (charm) around the
+aforementioned container image.
 
 Encapsulating the original 12-factor application in a charm allows your
 application to benefit from the entire

--- a/docs/explanation/foundations.rst
+++ b/docs/explanation/foundations.rst
@@ -1,0 +1,30 @@
+The foundations: Juju, charms and rocks
+=======================================
+
+The 12-factor web application solution uses and combines capabilities from the
+following Canonical products:
+
+- `Juju <https://juju.is>`_ is an open source orchestration engine for software
+  operators that enables the deployment, integration and lifecycle management
+  of applications at any scale and on any infrastructure.
+- A `charm <https://juju.is/docs/juju/charmed-operator>`_ is an operator -
+  business logic encapsulated in reusable software packages that automate every
+  aspect of an application's life.
+- `Charmcraft <https://canonical-charmcraft.readthedocs-hosted.com/en/stable/>`_
+  is a CLI tool that makes it easy and quick to initialize, package, and publish
+  charms.
+- `Rockcraft <https://documentation.ubuntu.com/rockcraft/en/latest/>`_ is a
+  tool to create rocks – a new generation of secure, stable and OCI-compliant
+  container images, based on Ubuntu.
+
+A Rockcraft framework (conceptually similar to a `snap
+extension <https://snapcraft.io/docs/snapcraft-extensions>`_) is initially
+used to facilitate the creation of a well structured, minimal and hardened
+container image, called a rock. A Charmcraft profile can then be leveraged to
+add a software operator (charm) around the aforementioned container image.
+
+Encapsulating the original 12-factor application in a charm allows your
+application to benefit from the entire
+`charm ecosystem <https://charmhub.io/>`_, meaning that the app
+can be connected to a database, e.g. an HA Postgres, observed through a Grafana
+based observability stack, add ingress and much more.

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -10,4 +10,5 @@ configuration of web app frameworks.
 .. toctree::
    :maxdepth: 1
 
+   foundations
    Charm architecture <charm-architecture>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ In this documentation
         :link: tutorial/index
         :link-type: doc
 
-        **Get started** - a hands-on introduction to the tooling
+        **Get started** with a hands-on introduction to the tooling
 
     .. grid-item-card:: How-to guides
         :link: how-to/index
@@ -49,13 +49,21 @@ In this documentation
         :link: reference/index
         :link-type: doc
 
-        **Technical information**
+        **Technical information** about the tooling
 
     .. grid-item-card:: Explanation
         :link: explanation/index
         :link-type: doc
 
         **Discussion and clarification** of key topics
+
+Since the tooling is natively part of the Rockcraft and Charmcraft products,
+additional documentation is available in their respective documentation sites:
+
+1. `Rockcraft <https://documentation.ubuntu.com/rockcraft/en/latest/reference/extensions/>`_:
+   Documentation related to the OCI image containers
+2. `Charmcraft <https://canonical-charmcraft.readthedocs-hosted.com/latest/reference/extensions/>`_:
+   Documentation related to the software operators (charms)
 
 Contributing to this documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,37 +24,6 @@ The solution is aimed at developers who create applications based on the
 can take advantage of the solution to simplify their operations and deploy
 their applications to production.
 
-The foundations: Juju, charms and rocks
----------------------------------------
-
-The 12-factor web application solution uses and combines capabilities from the
-following Canonical products:
-
-- `Juju <https://juju.is>`_ is an open source orchestration engine for software
-  operators that enables the deployment, integration and lifecycle management
-  of applications at any scale and on any infrastructure.
-- A `charm <https://juju.is/docs/juju/charmed-operator>`_ is an operator -
-  business logic encapsulated in reusable software packages that automate every
-  aspect of an application's life.
-- `Charmcraft <https://canonical-charmcraft.readthedocs-hosted.com/en/stable/>`_
-  is a CLI tool that makes it easy and quick to initialize, package, and publish
-  charms.
-- `Rockcraft <https://documentation.ubuntu.com/rockcraft/en/latest/>`_ is a
-  tool to create rocks – a new generation of secure, stable and OCI-compliant
-  container images, based on Ubuntu.
-
-A Rockcraft framework (conceptually similar to a `snap
-extension <https://snapcraft.io/docs/snapcraft-extensions>`_) is initially
-used to facilitate the creation of a well structured, minimal and hardened
-container image, called a rock. A Charmcraft profile can then be leveraged to
-add a software operator (charm) around the aforementioned container image.
-
-Encapsulating the original 12-factor application in a charm allows your
-application to benefit from the entire
-`charm ecosystem <https://charmhub.io/>`_, meaning that the app
-can be connected to a database, e.g. an HA Postgres, observed through a Grafana
-based observability stack, add ingress and much more.
-
 Documentation
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,16 +24,37 @@ The solution is aimed at developers who create applications based on the
 can take advantage of the solution to simplify their operations and deploy
 their applications to production.
 
-Documentation
--------------
+In this documentation
+---------------------
 
-Documentation for this project is located in a few places:
+.. grid:: 1 1 2 2
 
-1. This site: Documentation related to the product and development
-2. `Rockcraft <https://documentation.ubuntu.com/rockcraft/en/latest/>`_:
-   Documentation related to the OCI image containers
-3. `Charmcraft <https://canonical-charmcraft.readthedocs-hosted.com/en/stable/>`_:
-   Documentation related to the software operators (charms)
+    .. grid-item-card:: Tutorial
+        :link: tutorial/index
+        :link-type: doc
+
+        **Get started** - a hands-on introduction to the tooling
+
+    .. grid-item-card:: How-to guides
+        :link: how-to/index
+        :link-type: doc
+
+        **Step-by-step guides** covering key operations and common tasks
+
+.. grid:: 1 1 2 2
+    :reverse:
+
+    .. grid-item-card:: Reference
+        :link: reference/index
+        :link-type: doc
+
+        **Technical information**
+
+    .. grid-item-card:: Explanation
+        :link: explanation/index
+        :link-type: doc
+
+        **Discussion and clarification** of key topics
 
 Contributing to this documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,8 +62,8 @@ Contributing to this documentation
 Documentation is an important part of this project, and we take the same open-source
 approach to the documentation as the code. As such, we welcome community contributions,
 suggestions and constructive feedback on our documentation. Our documentation is hosted
-on Read The Docs to enable easy collaboration. Please use the "Edit this page on GitHub"
-or "Give Feedback" links on each documentation page to either directly change something
+on Read The Docs to enable easy collaboration. Please use the "Contribute to this page"
+links at the top of each documentation page to either directly change something
 you see that's wrong, ask a question, or make a suggestion about a potential change.
 
 If there's a particular area of documentation that you'd like to see that's missing,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ additional documentation is available in their respective documentation sites:
    Documentation related to the software operators (charms)
 
 Contributing to this documentation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------
 
 Documentation is an important part of this project, and we take the same open-source
 approach to the documentation as the code. As such, we welcome community contributions,
@@ -89,10 +89,12 @@ suggestions, fixes and constructive feedback.
 * `Get support <https://discourse.charmhub.io/>`_
 * `Join our online chat <https://matrix.to/#/#12-factor-charms:ubuntu.com>`_
 * :ref:`Contribute <how-to-contribute>`
-* Roadmap
 
-Thinking about using this solution in your next project? Get in touch!
+Get in touch
+~~~~~~~~~~~~
 
+Do you have a project or setup where you want to employ this solution? Reach out
+to share your use case and get started!
 
 .. toctree::
    :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,15 +14,16 @@ frameworks coming soon.
 
 With a few simple commands, you can set up a fully integrated and observable
 Kubernetes environment for your web application. These commands create
-production-ready OCI-compliant container images for your web application and
-software operators wrapped around the container images. From there, you can
-deploy your web application, connect it to a database, add ingress and
-observability and much more.
+production-ready container images for your web application compliant with
+the Open Container Initiative (OCI), along with software operators wrapped around
+the container images. From there, you can deploy your web application,
+connect it to a database, add ingress and observability and much more.
 
 The solution is aimed at developers who create applications based on the
 `12-factor methodology. <https://12factor.net/>`_ Web developers and operators
-can take advantage of the solution to simplify their operations and deploy
-their applications to production.
+can take advantage of the solution to quickly containerize their application,
+prepare their projects for deployment, and connect their application to the
+features that they need for full-scale production.
 
 In this documentation
 ---------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,11 +58,12 @@ In this documentation
         **Discussion and clarification** of key topics
 
 Since the tooling is natively part of the Rockcraft and Charmcraft products,
-additional documentation is available in their respective documentation sites:
+additional documentation is available in their respective documentation sites
+under the sections for tutorials, how-to guides, and reference material:
 
-1. `Rockcraft <https://documentation.ubuntu.com/rockcraft/en/latest/reference/extensions/>`_:
+1. `Rockcraft <https://documentation.ubuntu.com/rockcraft/en/latest/>`_:
    Documentation related to the OCI image containers
-2. `Charmcraft <https://canonical-charmcraft.readthedocs-hosted.com/latest/reference/extensions/>`_:
+2. `Charmcraft <https://canonical-charmcraft.readthedocs-hosted.com/latest/>`_:
    Documentation related to the software operators (charms)
 
 Contributing to this documentation


### PR DESCRIPTION
Applicable ticket: ISD-3630

### Overview

Refactor the RTD home page to not overwhelm the users with information upon visiting the site while providing an introduction consistent with Canonical's product documentation. 

### Rationale

* Add more information into the fourth paragraph (whom the product is useful for) to give more "why" and "how" the tooling can solve users' problems.
* Move the "foundations" section to a dedicated explanation page, so that the user isn't overwhelmed with information but can still read the page for a brief introduction to the Canonical products involved.
* Add "In this documentation" section to provide an experience consistent with other Canonical product documentation sites.
* Include more context for the Rockcraft and Charmcraft documentation links. Update those links to the extensions' reference pages to provide a focused entry point into the products.
* Provide more context with the final paragraph, and highlight the call to action with a dedicated "Get in touch" subsection.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The RTD documentation is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [X] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->