### PR TITLE
increase rabbitmq-k8s timeout when deploying

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -18,4 +18,3 @@ jobs:
       juju-channel: ${{ matrix.juju-version }}
       channel: 1.29-strict/stable
       test-timeout: 45
-      tmate-debug: true

--- a/.trivyignore
+++ b/.trivyignore
@@ -36,3 +36,5 @@ CVE-2025-24813
 CVE-2025-22235
 # org.postgresql:postgresql (spring-boot-0.0.1.jar)
 CVE-2025-49146
+# usr/local/bin/go-app (gobinary)
+CVE-2025-22874

--- a/tests/integration/integrations/conftest.py
+++ b/tests/integration/integrations/conftest.py
@@ -487,6 +487,6 @@ def deploy_rabbitmq_k8s_fixture(juju: jubilant.Juju) -> App:
     )
     juju.wait(
         lambda status: jubilant.all_active(status, rabbitmq_k8s.name),
-        timeout=6 * 60,
+        timeout=10 * 60,
     )
     return rabbitmq_k8s


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Increase waiting time for rabbitmq-k8s because it looks flaky with 6 min.
Remove tmate by default.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The RTD documentation is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
