### PR TITLE
docs: Refactor RTD tutorial landing page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## 2025-07-11
+
+* docs: Refactored the RTD tutorial landing page.
+
 ## 1.7.9 - 2025-06-26
 
 * feat: Added Prometheus support for Spring Boot.

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -19,22 +19,22 @@ or a fully deployed and integrated web app (Charmcraft).
     - Create a container image
     - Create a software operator and deploy
   * - Django
-    - `Build a rock for a Django application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/django/>`_
-    - `Write your first Kubernetes charm for a Django app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-django/>`_
+    - `Build a Django app rock <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/django/>`_
+    - `Write a Django app charm <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-django/>`_
   * - Express
-    - `Build a rock for an Express application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/expressjs/>`_
-    - `Write your first Kubernetes charm for an Express app <https://canonical-charmcraft.readthedocs-hosted.com/latest/tutorial/kubernetes-charm-express/>`_
+    - `Build an Express app rock <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/expressjs/>`_
+    - `Write an Express app charm <https://canonical-charmcraft.readthedocs-hosted.com/latest/tutorial/kubernetes-charm-express/>`_
   * - FastAPI
-    - `Build a rock for a FastAPI application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/fastapi/>`_
-    - `Write your first Kubernetes charm for a FastAPI app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-fastapi/>`_
+    - `Build a FastAPI app rock <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/fastapi/>`_
+    - `Write a FastAPI app charm <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-fastapi/>`_
   * - Flask
-    - `Build a rock for a Flask application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/flask/>`_
-    - `Write your first Kubernetes charm for a Flask app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-flask/>`_
+    - `Build a Flask app rock <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/flask/>`_
+    - `Write a Flask app charm <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-flask/>`_
   * - Go
-    - `Build a rock for a Go application <http://documentation.ubuntu.com/rockcraft/en/latest/tutorial/go/>`_
-    - `Write your first Kubernetes charm for a Go app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-go/>`_
+    - `Build a Go app rock <http://documentation.ubuntu.com/rockcraft/en/latest/tutorial/go/>`_
+    - `Write a Go app charm <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-go/>`_
   * - Spring Boot
-    - `Build a rock for a Spring Boot application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/springboot/>`_
-    - Coming soon: Write your first Kubernetes charm for a Spring Boot app
+    - `Build a Spring Boot app rock <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/springboot/>`_
+    - Coming soon: Write a Spring Boot app charm
 
 

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -13,10 +13,11 @@ or a fully deployed and integrated web app (Charmcraft).
 
 .. list-table::
   :header-rows: 1
+  :widths: 27 33 50
 
   * - Web app framework
     - Create a container image
-    - Create and deploy a web app
+    - Create a software operator and deploy
   * - Django
     - `Build a rock for a Django application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/django/>`_
     - `Write your first Kubernetes charm for a Django app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-django/>`_

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -4,20 +4,45 @@
 Tutorials
 =========
 
-For creating your first container image with the framework support tooling:
+Rockcraft and Charmcraft have comprehensive getting started tutorials teaching
+you to containerize a web app into an OCI-compliant container image, create a
+software operator around the container image, and set up a Kubernetes environment
+with ingress and a database. Each tutorial starts with building a basic
+"Hello, world" app and ends with either a functional container image or a fully
+deployed and integrated web app.
+
+Django
+~~~~~~
+
+* `Build a rock for a Django application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/django/>`_
+* `Write your first Kubernetes charm for a Django app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-django/>`_
+
+Express
+~~~~~~~
+
+* `Build a rock for an Express application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/expressjs/>`_
+* `Write your first Kubernetes charm for an Express app <https://canonical-charmcraft.readthedocs-hosted.com/latest/tutorial/kubernetes-charm-express/>`_
+
+FastAPI
+~~~~~~~
+
+* `Build a rock for a FastAPI application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/fastapi/>`_
+* `Write your first Kubernetes charm for a FastAPI app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-fastapi/>`_
+
+Flask
+~~~~~
 
 * `Build a rock for a Flask application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/flask/>`_
-* `Build a rock for a Django application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/django/>`_
-* `Build a rock for a FastAPI application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/fastapi/>`_
-* `Build a rock for a Go application <http://documentation.ubuntu.com/rockcraft/en/latest/tutorial/go/>`_
-* `Build a rock for an ExpressJS application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/expressjs/>`_
-
-For creating and deploying your first web app on Juju:
-
-* `Write your first Kubernetes charm for a Django app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-django/>`_
-* `Write your first Kubernetes charm for a FastAPI app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-fastapi/>`_
 * `Write your first Kubernetes charm for a Flask app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-flask/>`_
+
+Go
+~~
+
+* `Build a rock for a Go application <http://documentation.ubuntu.com/rockcraft/en/latest/tutorial/go/>`_
 * `Write your first Kubernetes charm for a Go app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-go/>`_
 
-Eventually, this project will contain developer tutorials for the tooling.
+Spring Boot
+~~~~~~~~~~~
 
+* `Build a rock for a Spring Boot application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/springboot/>`_
+* Coming soon: Write your first Kubernetes charm for a Spring Boot app

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -5,44 +5,35 @@ Tutorials
 =========
 
 Rockcraft and Charmcraft have comprehensive getting started tutorials teaching
-you to containerize a web app into an OCI-compliant container image, create a
+you to containerize a web app into an OCI-compliant image, create a
 software operator around the container image, and set up a Kubernetes environment
 with ingress and a database. Each tutorial starts with building a basic
-"Hello, world" app and ends with either a functional container image or a fully
-deployed and integrated web app.
+"Hello, world" app and ends with either a functional container image (Rockcraft)
+or a fully deployed and integrated web app (Charmcraft).
 
-Django
-~~~~~~
+.. list-table::
+  :header-rows: 1
 
-* `Build a rock for a Django application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/django/>`_
-* `Write your first Kubernetes charm for a Django app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-django/>`_
+  * - Web app framework
+    - Create a container image
+    - Create and deploy a web app
+  * - Django
+    - `Build a rock for a Django application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/django/>`_
+    - `Write your first Kubernetes charm for a Django app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-django/>`_
+  * - Express
+    - `Build a rock for an Express application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/expressjs/>`_
+    - `Write your first Kubernetes charm for an Express app <https://canonical-charmcraft.readthedocs-hosted.com/latest/tutorial/kubernetes-charm-express/>`_
+  * - FastAPI
+    - `Build a rock for a FastAPI application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/fastapi/>`_
+    - `Write your first Kubernetes charm for a FastAPI app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-fastapi/>`_
+  * - Flask
+    - `Build a rock for a Flask application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/flask/>`_
+    - `Write your first Kubernetes charm for a Flask app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-flask/>`_
+  * - Go
+    - `Build a rock for a Go application <http://documentation.ubuntu.com/rockcraft/en/latest/tutorial/go/>`_
+    - `Write your first Kubernetes charm for a Go app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-go/>`_
+  * - Spring Boot
+    - `Build a rock for a Spring Boot application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/springboot/>`_
+    - Coming soon: Write your first Kubernetes charm for a Spring Boot app
 
-Express
-~~~~~~~
 
-* `Build a rock for an Express application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/expressjs/>`_
-* `Write your first Kubernetes charm for an Express app <https://canonical-charmcraft.readthedocs-hosted.com/latest/tutorial/kubernetes-charm-express/>`_
-
-FastAPI
-~~~~~~~
-
-* `Build a rock for a FastAPI application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/fastapi/>`_
-* `Write your first Kubernetes charm for a FastAPI app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-fastapi/>`_
-
-Flask
-~~~~~
-
-* `Build a rock for a Flask application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/flask/>`_
-* `Write your first Kubernetes charm for a Flask app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-flask/>`_
-
-Go
-~~
-
-* `Build a rock for a Go application <http://documentation.ubuntu.com/rockcraft/en/latest/tutorial/go/>`_
-* `Write your first Kubernetes charm for a Go app <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/tutorial/kubernetes-charm-go/>`_
-
-Spring Boot
-~~~~~~~~~~~
-
-* `Build a rock for a Spring Boot application <https://documentation.ubuntu.com/rockcraft/en/latest/tutorial/springboot/>`_
-* Coming soon: Write your first Kubernetes charm for a Spring Boot app


### PR DESCRIPTION
Applicable ticket: ISD-3635

### Overview

Refactor the RTD tutorial landing page.

### Rationale

* Include a description paragraph giving an overview of the tutorials on the landing page, ensuring it's framed around why/how this solves the user’s problem.
* Reorganize the links into a table, shortening the titles to reduce repetition and establishing a mental map between terms that the user knows (container images, software operators) with Canonical product terminology (rocks, charms).

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The RTD documentation is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [X] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
