### PR TITLE
add trace ID to logs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## 1.8.1 - 2025-07-25
+
+* feat: add X-Request-ID header to Gunicorn logs if present in response.
+
 ## 1.8.0 - 2025-07-24
 
 * feat: Add OIDC support for Flask.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 [project]
 name = "paas-charm"
-version = "1.8.0"
+version = "1.8.1"
 description = "Companion library for 12-factor app support in Charmcraft & Rockcraft."
 readme = "README.md"
 authors = [

--- a/src/paas_charm/templates/gunicorn.conf.py.j2
+++ b/src/paas_charm/templates/gunicorn.conf.py.j2
@@ -14,6 +14,7 @@ statsd_host = '{{ statsd_host }}'
 {{ key }} = {{ value }}
 {%- endfor -%}
 {%- if enable_tracing %}
+access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({x-request-id}o)s'
 
 
 def post_fork(server, worker):

--- a/tests/unit/flask/test_webserver.py
+++ b/tests/unit/flask/test_webserver.py
@@ -67,6 +67,7 @@ GUNICORN_CONFIG_TEST_PARAMS = [
                 accesslog = '/var/log/flask/access.log'
                 errorlog = '/var/log/flask/error.log'
                 statsd_host = 'localhost:9125'
+                access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({x-request-id}o)s'
 
 
                 def post_fork(server, worker):


### PR DESCRIPTION
### Overview

This adds the trace ID to log lines if tracing is enabled. By convention, the [X-Request-ID](https://http.dev/x-request-id) header is use to identity a request coming from the client to the server and back. 

The header must be populated from the application side.

### Rationale

Adding trace IDs to logs allows for linking the logs to traces on grafana, allowing for easy traveral between the two when debugging problems. Fixes #99 

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->
N/A
### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->
N/A
### Library Changes

<!-- Any changes to charm libraries -->
N/A
### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The RTD documentation is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
