### PR TITLE
Fix trivy errors. Add statsd exception.

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -41,3 +41,5 @@ CVE-2025-22235
 CVE-2025-49146
 # usr/local/bin/go-app (gobinary)
 CVE-2025-22874
+# usr/bin/statsd_exporter (gobinary)
+CVE-2025-22868

--- a/examples/flask/test_rock/app.py
+++ b/examples/flask/test_rock/app.py
@@ -353,7 +353,7 @@ def s3_status():
     """S3 status endpoint."""
     if client := get_boto3_client():
         bucket_name = os.environ["S3_BUCKET"]
-        objectsresponse = client.list_objects(Bucket=bucket_name)
+        _ = client.list_objects(Bucket=bucket_name)
         return "SUCCESS"
     return "FAIL", 500
 

--- a/tests/integration/flask/test_database.py
+++ b/tests/integration/flask/test_database.py
@@ -48,19 +48,17 @@ async def test_with_database(
         deploy_cmd.extend(["--trust"])
     await ops_test.juju(*deploy_cmd)
 
-    # mypy doesn't see that ActiveStatus has a name
-    await model.wait_for_idle(status=ops.ActiveStatus.name)  # type: ignore
+    await model.wait_for_idle(status=ops.ActiveStatus.name)
 
     await model.add_relation(flask_app.name, db_name)
 
-    # mypy doesn't see that ActiveStatus has a name
-    await model.wait_for_idle(status=ops.ActiveStatus.name)  # type: ignore
+    await model.wait_for_idle(status=ops.ActiveStatus.name)
 
     for unit_ip in await get_unit_ips(flask_app.name):
         for _ in range(10):
             response = requests.get(f"http://{unit_ip}:8000/{endpoint}", timeout=5)
-            assert response.status_code == 200
             if "SUCCESS" == response.text:
                 return
             await asyncio.sleep(60)
+        assert response.status_code == 200
         assert "SUCCESS" == response.text


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

This new trivy ignore is necessary for the integration tests to pass (related to the statsd binary).

Also a minor improvement to the database integration test, as was failing for 200 and then checking for SUCCESS and that means that the retry was not being effective.

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The RTD documentation is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
