### PR TITLE
docs: How to add a new framework

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## 2025-07-23
+
+* docs: Added "How to add a new framework".
+
 ## 2025-07-21
 
 * docs: Refactor reference documentation.

--- a/docs/how-to/add-new-framework.rst
+++ b/docs/how-to/add-new-framework.rst
@@ -1,0 +1,5 @@
+.. _how_to_add_new_framework:
+
+How to add a new framework
+==========================
+

--- a/docs/how-to/add-new-framework.rst
+++ b/docs/how-to/add-new-framework.rst
@@ -3,3 +3,56 @@
 How to add a new framework
 ==========================
 
+This guide describes the process for adding a new framework to ``paas-charm``
+and the corresponding support in Rockcraft and Charmcraft.
+
+Describe use case
+-----------------
+
+Reach out to us on `Matrix <https://matrix.to/#/#12-factor-charms:ubuntu.com>`_
+with your use case and need. So we can understand the full context, it's helpful
+if you have a working app that demonstrates your use case.
+We then determine whether the 12-factor tooling is an appropriate solution and
+will meet the requirements of your use case. During this stage, we conduct a
+thorough evaluation to understand the time requirements, priority, and whether
+your use case fits into the 12-factor story.
+
+Work into roadmap
+-----------------
+
+Before any development begins, we must add the work into our official roadmap.
+During routine roadmap planning, we further evaluate your use case, stakeholders,
+and relevant needs. If approved, the framework development
+and implementation is added to upcoming cycles in our roadmap.
+
+Develop
+-------
+
+Once the work is added to our official roadmap, we can begin developing the
+new framework. Your role now shifts from *requester* to *stakeholder*, where you
+will attend meetings, review and approve any functional specifications, and
+provide your input on  the user experience, features, framework assumptions,
+processes, and practices.
+
+Implement
+---------
+
+The implementation process has a three-staged approach, where implementing the
+Rockcraft support always occurs first. The support in ``paas-charm`` and Charmcraft can
+be worked on simultaneously, and the order of their implementation can alternate.
+
+Once the implementation happens, the initial framework support will be behind
+an experimental flag. This flag is removed only after significant
+testing has occurred and we have a production-ready deployment. 
+After the experimental flag is removed, no breaking changes will be allowed for
+the framework until the next ``paas-charm`` LTS release.
+
+Add more features
+-----------------
+
+If you require additional features in the framework, determine whether the features
+need to be added to ``pass-charm``, Rockcraft, or Charmcraft.
+Follow the :ref:`contributing guide <how_to_contribute>` for ``paas-charm`` or the contributing
+guides in `Rockcraft <https://github.com/canonical/rockcraft/blob/main/CONTRIBUTING.rst>`_
+and `Charmcraft <https://github.com/canonical/charmcraft/blob/main/CONTRIBUTING.md>`_.
+

--- a/docs/how-to/contributing.rst
+++ b/docs/how-to/contributing.rst
@@ -1,6 +1,6 @@
 .. Copyright 2025 Canonical Ltd.
 .. See LICENSE file for licensing details.
-.. _how-to-contribute:
+.. _how_to_contribute:
 
 .. TODO: Update all sections containing TODOs; make sure no TODOs are left
 

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -17,5 +17,6 @@ This site contains step-by-step instructions for developing and maintaining a fr
 .. toctree::
    :maxdepth: 1
 
+   Add a new framework <add-new-framework>
    Contribute <contributing>
    Upgrade <upgrade>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -89,7 +89,7 @@ suggestions, fixes and constructive feedback.
 * `Code of conduct <https://ubuntu.com/community/ethos/code-of-conduct>`_
 * `Get support <https://discourse.charmhub.io/>`_
 * `Join our online chat <https://matrix.to/#/#12-factor-charms:ubuntu.com>`_
-* :ref:`Contribute <how-to-contribute>`
+* :ref:`Contribute <how_to_contribute>`
 
 Get in touch
 ~~~~~~~~~~~~


### PR DESCRIPTION
Applicable ticket: ISD-3523

### Overview

Add a new how-to guide, "How to add a new framework".

### Rationale

This guide provides visibility and transparency about the process behind adding a new framework, including the level of involvement and role of the original requester.

In this PR, I also updated the contributing document's reference target as a small additional improvement. This helps standardize the reference targets.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The RTD documentation is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [X] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
