### PR TITLE
docs: Refactor how-to landing page

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## 2025-07-30
+
+* docs: Refactor how-to landing page.
+
 ## 1.8.4 - 2025-07-29
 
 * feat: Add OIDC support for FastAPI.
@@ -20,7 +24,7 @@ Place any unreleased changes here, that are subject to release in coming version
 ## 1.8.2 - 2025-07-28
 
 * feat: Add OIDC support for Django.
-* * docs: Added "Supported customizable features and capabilities".
+* docs: Added "Supported customizable features and capabilities".
 
 ## 1.8.1 - 2025-07-25
 

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -4,17 +4,55 @@
 How-to guides
 =============
 
+The following guides provide comprehensive, step-by-step instructions for the common
+tasks related to the 12-factor tooling, from working with the relevant products to
+contributing.
+
+Manage a 12-factor app rock
+---------------------------
+
 The Rockcraft documentation contains a set of how-to guides for managing
-a 12-factor app container image:
-`How to build a 12-Factor app rock <https://documentation.ubuntu.com/rockcraft/en/latest/how-to/build-a-12-factor-app-rock/>`_
+a 12-factor app container image.
+
+* `Manage a 12-Factor app rock <https://documentation.ubuntu.com/rockcraft/en/latest/how-to/build-a-12-factor-app-rock/>`_
+   * `Set up a 12-Factor app rock <https://documentation.ubuntu.com/rockcraft/en/latest/how-to/web-app-rocks/set-up-web-app-rock/>`_:
+     Initialize and configure a rock using the 12-factor extensions.
+   * `Use a 12-Factor app rock <https://documentation.ubuntu.com/rockcraft/en/latest/how-to/web-app-rocks/use-web-app-rock/>`_:
+     Learn about the various ways you can use and update your rock.
+
+Manage a 12-factor app charm
+----------------------------
 
 The Charmcraft documentation contains a set of how-to guides for initializing,
-configuring, integrating, and using a 12-factor app charm:
-`Manage a 12-factor app charm <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/howto/manage-web-app-charms/>`_
+configuring, integrating, and using a 12-factor app charm.
 
-This site contains step-by-step instructions for developing and maintaining a framework in the 12-factor app project.
+* `Manage a 12-factor app charm <https://canonical-charmcraft.readthedocs-hosted.com/en/latest/howto/manage-web-app-charms/>`_:
+   * `Initialization <https://canonical-charmcraft.readthedocs-hosted.com/latest/howto/manage-web-app-charms/#initialization>`_
+   * `Configuration <https://canonical-charmcraft.readthedocs-hosted.com/latest/howto/manage-web-app-charms/configure-web-app-charm/>`_:
+     The 12-factor tooling includes different ways you can customize to fit your use case.
+     These guides provide instructions on tasks like adding configurations, actions, and
+     managing secrets.
+   * `Relations <https://canonical-charmcraft.readthedocs-hosted.com/latest/howto/manage-web-app-charms/integrate-web-app-charm/>`_:
+     The tooling provides you the ability to integrate with preexisting charms in the
+     Juju ecosystem. These guides get you started with three commonly used relations:
+     databases, ingress, and observability.
+   * `Usage <https://canonical-charmcraft.readthedocs-hosted.com/latest/howto/manage-web-app-charms/use-web-app-charm/>`_:
+     Learn more about tasks such as migrations and troubleshooting.
+
+Contribute to the project
+-------------------------
+
+Below are step-by-step instructions for developing and contributing to the 12-factor app project.
+
+* :ref:`Add a new framework <how_to_add_new_framework>`: A guide that details the process for
+  contributing to the 12-factor project, Rockcraft, and Charmcraft.
+* :ref:`Contribute <how_to_contribute>`: Recommended processes and practices for contributing
+  enhancements to the 12-factor project
+* :ref:`Upgrade <how_to_upgrade>`: Information for upgrading your 12-factor app rock, deployed
+  charm, or ``paas-charm`` version. 
 
 .. toctree::
+   :hidden:
    :maxdepth: 1
 
    Add a new framework <add-new-framework>


### PR DESCRIPTION
Applicable spec: ISD-3636

### Overview

Refactor the how-to landing page.

### Rationale

Improve transparency of the various aspects of the project and improve the user journey.
* Add dedicated section headers for Rockcraft, Charmcraft, and developer documentation
* Add descriptions for each of the pages so the user knows what to expect from each page

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The RTD documentation is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [X] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
