### PR TITLE
Add target header to explanation index

### DIFF
--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -1,6 +1,8 @@
 .. Copyright 2025 Canonical Ltd.
 .. See LICENSE file for licensing details.
 
+.. _explanation:
+
 Explanation
 ===========
 


### PR DESCRIPTION
### Overview

Add target header to explanation index page.

### Rationale

Needed to set up the intersphinx mapping between the Charmcraft project and this RTD project.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The RTD documentation is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
