### PR TITLE
docs: Refactor explanation documentation

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## 2025-08-25
+
+* docs: Refactor explanation documentation in the RTD site.
+
 ## 2025-08-21
 
 * docs: Add links to Spring Boot documentation.

--- a/docs/explanation/charm-architecture.rst
+++ b/docs/explanation/charm-architecture.rst
@@ -25,18 +25,13 @@ as databases and ingress, using open source tooling.
 The charm design leverages the
 `sidecar <https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/#example-1-sidecar-containers>`_
 pattern to allow multiple containers in each pod with `Pebble <https://juju.is/docs/sdk/pebble>`_
-running as the workload container’s entrypoint.
+running as the containers' entrypoint.
 Pebble is a lightweight, API-driven process supervisor that is responsible for
 configuring processes to run in a container and controlling those processes
 throughout the workload lifecycle.
 
-Pebble `services` are configured through `layers <https://github.com/canonical/pebble#layer-specification>`_,
-and the following container represents a layer forming the effective
-Pebble configuration, or `plan`:
-
-1. An :code:`app` container, which contains the workload to run in any of the supported web frameworks.
-
-
+The charm consists of an ``app`` container which contains the workload
+to run in any of the supported web frameworks.
 As a result, if you run a :code:`kubectl get pods` on a namespace named for the Juju model
 you've deployed the web app charm into, you'll see something like the following:
 

--- a/docs/explanation/charm-architecture.rst
+++ b/docs/explanation/charm-architecture.rst
@@ -46,7 +46,7 @@ you've deployed the web app charm into, you'll see something like the following:
    NAME                          READY   STATUS    RESTARTS   AGE
    web-app-0                     2/2     Running   0          6h4m
 
-This shows there are 2 containers - the named above, as well as a container for the charm code itself.
+This shows there are two containers - the named above, as well as a container for the charm code itself.
 
 And if you run :code:`kubectl describe pod web-app-0`, all the containers will have
 as Command :code:`/charm/bin/pebble`. That's because Pebble is responsible for the

--- a/docs/explanation/charm-architecture.rst
+++ b/docs/explanation/charm-architecture.rst
@@ -20,19 +20,18 @@ Charm architecture
 
 Web app support in Charmcraft and Rockcraft is a framework to easily deploy and
 operate your web app workloads and associated infrastructure, such
-as databases and ingress, using open source tooling.
+as databases and ingress, using open source tooling. 
 
-The resulting charm design leverages the
+The charm design leverages the
 `sidecar <https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/#example-1-sidecar-containers>`_
 pattern to allow multiple containers in each pod with `Pebble <https://juju.is/docs/sdk/pebble>`_
 running as the workload container’s entrypoint.
-
 Pebble is a lightweight, API-driven process supervisor that is responsible for
 configuring processes to run in a container and controlling those processes
 throughout the workload lifecycle.
 
 Pebble `services` are configured through `layers <https://github.com/canonical/pebble#layer-specification>`_,
-and the following containers represent each one a layer forming the effective
+and the following container represents a layer forming the effective
 Pebble configuration, or `plan`:
 
 1. An :code:`app` container, which contains the workload to run in any of the supported web frameworks.
@@ -47,9 +46,10 @@ you've deployed the web app charm into, you'll see something like the following:
    web-app-0                     2/2     Running   0          6h4m
 
 This shows there are two containers - the named above, as well as a container for the charm code itself.
+The charm container logic is determined by the ``paas-charm`` library.
 
 And if you run :code:`kubectl describe pod web-app-0`, all the containers will have
-as Command :code:`/charm/bin/pebble`. That's because Pebble is responsible for the
+the command :code:`/charm/bin/pebble`. That's because Pebble is responsible for the
 processes startup.
 
 OCI images

--- a/docs/explanation/charm-architecture.rst
+++ b/docs/explanation/charm-architecture.rst
@@ -1,35 +1,9 @@
 .. Copyright 2025 Canonical Ltd.
 .. See LICENSE file for licensing details.
-.. _charm-architecture:
+.. _explanation_charm_architecture:
 
 Charm architecture
 ==================
-
-Web app support in Charmcraft and Rockcraft is a framework to easily deploy and operate your Flask, Django, FastAPI or Go workloads and associated infrastructure, such
-as databases and ingress, using open source tooling.
-
-The resulting charm design leverages the `sidecar <https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/#example-1-sidecar-containers>`_ pattern to allow multiple containers in each pod with `Pebble <https://juju.is/docs/sdk/pebble>`_ running as the workload container’s entrypoint.
-
-Pebble is a lightweight, API-driven process supervisor that is responsible for configuring processes to run in a container and controlling those processes throughout the workload lifecycle.
-
-Pebble `services` are configured through `layers <https://github.com/canonical/pebble#layer-specification>`_, and the following containers represent each one a layer forming the effective Pebble configuration, or `plan`:
-
-1. An :code:`app` container, which contains the workload to run in any of the supported web frameworks.
-
-
-As a result, if you run a :code:`kubectl get pods` on a namespace named for the Juju model you've deployed the web app charm into, you'll see something like the following:
-
-.. code-block:: text
-
-   NAME                          READY   STATUS    RESTARTS   AGE
-   web-app-0                     2/2     Running   0          6h4m
-
-This shows there are 2 containers - the named above, as well as a container for the charm code itself.
-
-And if you run :code:`kubectl describe pod web-app-0`, all the containers will have as Command :code:`/charm/bin/pebble`. That's because Pebble is responsible for the processes startup as explained above.
-
-Charm architecture diagram
---------------------------
 
 .. mermaid::
 
@@ -44,6 +18,40 @@ Charm architecture diagram
    }
    Rel(charm_logic, workload, "Supervises<br>process")
 
+Web app support in Charmcraft and Rockcraft is a framework to easily deploy and
+operate your web app workloads and associated infrastructure, such
+as databases and ingress, using open source tooling.
+
+The resulting charm design leverages the
+`sidecar <https://kubernetes.io/blog/2015/06/the-distributed-system-toolkit-patterns/#example-1-sidecar-containers>`_
+pattern to allow multiple containers in each pod with `Pebble <https://juju.is/docs/sdk/pebble>`_
+running as the workload container’s entrypoint.
+
+Pebble is a lightweight, API-driven process supervisor that is responsible for
+configuring processes to run in a container and controlling those processes
+throughout the workload lifecycle.
+
+Pebble `services` are configured through `layers <https://github.com/canonical/pebble#layer-specification>`_,
+and the following containers represent each one a layer forming the effective
+Pebble configuration, or `plan`:
+
+1. An :code:`app` container, which contains the workload to run in any of the supported web frameworks.
+
+
+As a result, if you run a :code:`kubectl get pods` on a namespace named for the Juju model
+you've deployed the web app charm into, you'll see something like the following:
+
+.. code-block:: text
+
+   NAME                          READY   STATUS    RESTARTS   AGE
+   web-app-0                     2/2     Running   0          6h4m
+
+This shows there are 2 containers - the named above, as well as a container for the charm code itself.
+
+And if you run :code:`kubectl describe pod web-app-0`, all the containers will have
+as Command :code:`/charm/bin/pebble`. That's because Pebble is responsible for the
+processes startup.
+
 OCI images
 ----------
 
@@ -55,27 +63,16 @@ We use `Rockcraft <https://canonical-rockcraft.readthedocs-hosted.com/en/latest/
    
    `Build a 12-factor app rock <https://documentation.ubuntu.com/rockcraft/en/latest/how-to/build-a-12-factor-app-rock/>`_
 
-
-Metrics
--------
-The provided support for metrics and tracing depends on the enabled extension.
-
-.. seealso:: 
-
-   `Charmcraft reference | Extensions <https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/extensions/>`_.
-
-Integrations
-------------
-The available integrations, including those that are already pre-populated, varies between extensions.
-
-.. seealso::
-
-   `Charmcraft reference | Extensions <https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/extensions/>`_.
-
 Juju events
 -----------
 
-See :ref:`ref_juju_events`.
+Juju handles updates or changes to the charm and system through hooks, or events.
+These notifications provides the charm information that the system has changed
+and thus prompts a reaction from the charm to respond to the change, taking
+into account the charm's configuration.
+
+For more information on the events observed by 12-factor app charms, see
+:ref:`ref_juju_events`.
 
 Charm code overview
 -------------------

--- a/docs/explanation/foundations.rst
+++ b/docs/explanation/foundations.rst
@@ -1,3 +1,5 @@
+.. _explanation_foundations:
+
 The foundations: Juju, charms and rocks
 =======================================
 

--- a/docs/explanation/full-lifecycle.rst
+++ b/docs/explanation/full-lifecycle.rst
@@ -1,3 +1,5 @@
+.. _explanation_full_lifecycle:
+
 How everything connects (source to production)
 ==============================================
 

--- a/docs/explanation/how-are-12-factor-principles-applied.rst
+++ b/docs/explanation/how-are-12-factor-principles-applied.rst
@@ -1,3 +1,5 @@
+.. _explanation_12_factor_principles_applied:
+
 How 12-Factor app principles are applied in rocks and charms
 ============================================================
 

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -47,7 +47,7 @@ to focus on their core competences instead of a complex software stack.
 * :ref:`Web app framework <explanation_web_app_frameworks>`: More details about the
   supported web app frameworks.
 
-12-Factor app charm
+12-factor app charm
 -------------------
 
 The software operator built with Charmcraft containerizes the web app workload so that

--- a/docs/explanation/index.rst
+++ b/docs/explanation/index.rst
@@ -12,6 +12,24 @@ configuration of web app frameworks.
 12-factor app principles
 ------------------------
 
+The glue point of the 12-factor framework support in Rockcraft and Charmcraft is
+the `12-factor methodology <https://12factor.net/>`_. The 12-Factor methodology
+is a set of best practices for building modern, scalable, and maintainable web
+applications. By following these principles, you can easily create a rock
+(OCI image) and a charm (software operator) for your web app that can take
+advantage of the full Juju ecosystem.
+
+Learn more about the components involved and how the principles are applied in
+the following pages:
+
+* :ref:`Juju, charms and rocks <explanation_foundations>`: Descriptions of
+  the Canonical products involved. 
+* :ref:`How the 12-factor principles are applied in rocks and charms <explanation_12_factor_principles_applied>`: 
+  An overview on how the 12-factor methodology is applied to rocks and charms.
+
+12-factor ecosystem
+-------------------
+
 The native 12-factor framework support in Rockcraft and Charmcraft provides an
 opinionated way to easily integrate your web application into the Juju ecosystem.
 The Juju ecosystem provides a multitude of `curated software operators <https://charmhub.io/>`_
@@ -24,26 +42,27 @@ a fully fledged Platform as a Service that streamlines managing the
 infrastructure, whether on premises or on cloud, at any scale, and allows developers
 to focus on their core competences instead of a complex software stack.
 
-The glue point of the 12-factor framework support in Rockcraft and Charmcraft is
-the `12-factor methodology <https://12factor.net/>`_. The 12-Factor methodology
-is a set of best practices for building modern, scalable, and maintainable web
-applications. By following these principles, you can easily create a rock
-(OCI image) and a charm (software operator) for your web app that can take
-advantage of the full Juju ecosystem.
+* :ref:`How everything connects <explanation_full_lifecycle>`: An overview of how the
+  various components come together to form the 12-factor ecosystem.
+* :ref:`Web app framework <explanation_web_app_frameworks>`: More details about the
+  supported web app frameworks.
 
-12-Factor principles and its support in Charmcraft and Rockcraft
-----------------------------------------------------------------
+12-Factor app charm
+-------------------
 
-The 12-Factor app support in Charmcraft and Rockcraft is based on the principles
-stated in the 12-Factor methodology. Learn more about the components
-involved and how the principles are applied in the following links.
+The software operator built with Charmcraft containerizes the web app workload so that
+you can deploy, configure, and integrate your web app in the Juju ecosystem. The following
+page provides an overview of the architecture, components, and source code.
+
+* :ref:`Charm architecture <explanation_charm_architecture>`
 
 .. toctree::
    :maxdepth: 1
    :numbered:
+   :hidden:
 
    Juju, charms and rocks <foundations>
-   How the 12-Factor principles are applied in rocks and charms <how-are-12-factor-principles-applied>
-   How everything connects (source to production) <full-lifecycle>
+   How the 12-factor principles are applied in rocks and charms <how-are-12-factor-principles-applied>
+   The 12-factor ecosystem <full-lifecycle>
    Web app framework <web-app-framework>
    Charm architecture <charm-architecture>

--- a/docs/explanation/web-app-framework.rst
+++ b/docs/explanation/web-app-framework.rst
@@ -1,3 +1,5 @@
+.. _explanation_web_app_frameworks:
+
 Web app framework
 =================
 


### PR DESCRIPTION
Applicable tickets: ISD-3629, ISD-3639

### Overview

Refactor explanation pages and landing page in the 12-factor RTD site.

### Rationale

Incorporate feedback from user journey interviews, and iterate on the explanation documentation previously added to the site.
Break up the TOC into different sections depending on the topic. Reorganized the content on the landing page.
For the "charm architecture" page, moved the diagram to the top of the page and removed the "Metrics" and "Integrations" sections. Added a bit more content under the "Events" section but ultimately pointed the user to the reference documentation.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The RTD documentation is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [X] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
