### PR TITLE
Refresh ingress on update_status

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -45,6 +45,6 @@ jobs:
         ]
       rockcraft-channel: latest/edge
       juju-channel: ${{ matrix.juju-version }}
-      channel: 1.29-strict/stable
+      channel: 1.31-strict/stable
       test-timeout: 45
       microk8s-addons: "dns ingress rbac storage metallb:10.64.140.43-10.64.140.49"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+* fix: The ingress library doesn't properly handle pod restarts, and in some cases
+  using the nginx-integrator charm, the IP field is not updated correctly.
+  As a workaround, refresh the ingress relation data on every update-status hook.
+
 ## 2025-08-25
 
 * docs: Refactor explanation documentation in the RTD site.

--- a/src/paas_charm/charm.py
+++ b/src/paas_charm/charm.py
@@ -685,6 +685,12 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
         """Handle the update-status event."""
         if self._database_migration.get_status() == DatabaseMigrationStatus.FAILED:
             self.restart()
+        # Sometimes the ingress library doesn't properly handle pod
+        # restarts,which can cause the IP field inside the ingress
+        # relation data to become stale, resulting in ingress failures.
+        # As a workaround, force refresh the ingress relation data
+        # (especially the ip field) on every update status.
+        self._ingress._publish_auto_data()
 
     @block_if_invalid_config
     def _on_mysql_database_database_created(self, _: DatabaseRequiresEvent) -> None:

--- a/tests/integration/integrations/test_tracing.py
+++ b/tests/integration/integrations/test_tracing.py
@@ -45,7 +45,7 @@ def test_workload_tracing(
     juju.integrate(f"{app.name}:tracing", f"{tempo_app}:tracing")
 
     juju.wait(
-        lambda status: jubilant.all_active(status, app.name, tempo_app), timeout=1800, delay=5
+        lambda status: jubilant.all_active(status, app.name, tempo_app), timeout=600, delay=5
     )
     status = juju.status()
     unit_ip = status.apps[app.name].units[app.name + "/0"].address


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

The ingress library doesn't properly handle pod restarts, and in some cases  using the nginx-integrator charm, the IP field is not updated correctly. As a workaround, refresh the ingress relation data on every update-status hook.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The RTD documentation is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
