### PR TITLE
Fix: Do not remove the trailing '/' in the redirect uri

### DIFF
--- a/src/paas_charm/oauth.py
+++ b/src/paas_charm/oauth.py
@@ -129,7 +129,7 @@ class PaaSOAuthRequirer(OAuthRequirer):
         scopes = str(self._charm_config.get(f"{relation_name}-scopes"))
 
         return ClientConfig(
-            redirect_uri=f"{self._base_url}/{redirect_path.strip('/')}",
+            redirect_uri=f"{self._base_url}/{redirect_path.lstrip('/')}",
             scope=scopes,
             grant_types=["authorization_code"],
         )


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Some providers force you to use trailing `/` characters in the redirect url of OIDC.

Fixing the issue of removing any trailing `/` characters here by using `lstrip` instead of `strip`
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The RTD documentation is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
