### PR TITLE
docs: Add table with minimum supported versions of frameworks

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## 2025-09-15
+
+* docs: Add table with minimum supported versions of the frameworks.
+
 ## 2025-09-11
 
 * docs: Add explanation document describing the opinionated nature of the 12-factor tooling.

--- a/docs/explanation/opinionated-nature-tooling.rst
+++ b/docs/explanation/opinionated-nature-tooling.rst
@@ -143,9 +143,29 @@ executable file, or if it finds both files or both executable files.
 Minimum supported versions of the frameworks
 --------------------------------------------
 
-Not all versions of the web app frameworks are supported. Check with us on the
-`Matrix channel <https://matrix.to/#/#12-factor-charms:ubuntu.com>`_ if you have
-questions about supported web app framework versions for the 12-factor tooling.
+Not all versions of the web app frameworks are supported. 
+
+The following table outlines the minimum versions that are expected to work with the
+12-factor tooling.
+
+.. list-table::
+  :header-rows: 1
+  :widths: 1 1
+
+  * - Web app framework
+    - Minimum supported version
+  * - Django
+    - ???
+  * - Express
+    - ???
+  * - FastAPI
+    - ???
+  * - Flask
+    - ???
+  * - Go
+    - ???
+  * - Spring Boot
+    - ???
 
 Opinions related to the base
 ----------------------------


### PR DESCRIPTION
### Overview

Add a table summarizing the minimum supported versions of the web app frameworks.

### Rationale

Helps clarify the opinionated nature of the tooling

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The RTD documentation is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [X] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
