### PR TITLE
Fix broken links

### DIFF
--- a/docs/reference/supported-customization.rst
+++ b/docs/reference/supported-customization.rst
@@ -19,24 +19,24 @@ in a 12-factor app rock and charm:
 
         .. group-tab:: Django
 
-            `Charmcraft Django extension | Background tasks <https://canonical-charmcraft.readthedocs-hosted.com/latest/reference/extensions/django-framework-extension/#background-tasks>`_
+            `Charmcraft Django extension | Worker and Scheduler Services <https://documentation.ubuntu.com/charmcraft/latest/reference/extensions/django-framework-extension/#worker-and-scheduler-services>`_
 
         .. group-tab:: Express
 
-            `Charmcraft Express extension | Background tasks <https://canonical-charmcraft.readthedocs-hosted.com/latest/reference/extensions/express-framework-extension/#background-tasks>`_
+            `Charmcraft Express extension | Worker and Scheduler Services <https://documentation.ubuntu.com/charmcraft/latest/reference/extensions/express-framework-extension/#worker-and-scheduler-services>`_
 
         .. group-tab:: FastAPI
 
-            `Charmcraft FastAPI extension | Background tasks <https://canonical-charmcraft.readthedocs-hosted.com/latest/reference/extensions/fastapi-framework-extension/#background-tasks>`_
+            `Charmcraft FastAPI extension | Worker and Scheduler Services <https://documentation.ubuntu.com/charmcraft/latest/reference/extensions/fastapi-framework-extension/#worker-and-scheduler-services>`_
 
         .. group-tab:: Flask
 
-            `Charmcraft Flask extension | Background tasks <https://canonical-charmcraft.readthedocs-hosted.com/latest/reference/extensions/flask-framework-extension/#background-tasks>`_
+            `Charmcraft Flask extension | Worker and Scheduler Services <https://documentation.ubuntu.com/charmcraft/latest/reference/extensions/flask-framework-extension/#worker-and-scheduler-services>`_
 
         .. group-tab:: Go
 
-            `Charmcraft Go extension | Background tasks <https://canonical-charmcraft.readthedocs-hosted.com/latest/reference/extensions/go-framework-extension/#background-tasks>`_
+            `Charmcraft Go extension | Worker and Scheduler Services <https://documentation.ubuntu.com/charmcraft/latest/reference/extensions/go-framework-extension/#worker-and-scheduler-services>`_
 
         .. group-tab:: Spring Boot
 
-            `Charmcraft Spring Boot extension | Background tasks <https://documentation.ubuntu.com/charmcraft/latest/reference/extensions/spring-boot-framework-extension/#background-tasks>`_
+            `Charmcraft Spring Boot extension | Worker and Scheduler Services <https://documentation.ubuntu.com/charmcraft/latest/reference/extensions/spring-boot-framework-extension/#worker-and-scheduler-services>`_


### PR DESCRIPTION
### Overview

Fix broken links in `docs/reference/supported-customization.rst`.

### Rationale

Broken links are causing the documentation checks to fail for other PRs, e.g., https://github.com/canonical/paas-charm/pull/168

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [X] The RTD documentation is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
Didn't update the changelog because it's a minor update.
