### PR TITLE
Only access other units in rabbitmq

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+* fix: Fix bug in rabbitmq relation. When an application with units integrate with
+       rabbitmq-server it can fail with RelationDataAccessError.
+
 ## 2025-10-01
 
 * docs: Add link to Matrix channel in README.

--- a/src/paas_charm/rabbitmq.py
+++ b/src/paas_charm/rabbitmq.py
@@ -190,7 +190,7 @@ class RabbitMQRequires(Object):
         """The RabbitMQ hostname, password."""
         if not self._rabbitmq_rel:
             return None
-        for unit in self._rabbitmq_rel.data:
+        for unit in self._rabbitmq_rel.units:
             unit_data = self._rabbitmq_rel.data[unit]
             # All of the passwords should be equal. If it is
             # in the unit data, get it and override the password


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Fixes: https://github.com/canonical/paas-charm/issues/174

There is a bug in how we get the hostname and password for rabbitmq-server.

As we iterate over all elements of the relation databag, we get both sides of the relation. From the current side, the app databag will fail if the unit is not the leader, getting the unit in error state.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The RTD documentation is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
