### PR TITLE
Add `http-proxy` integration

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+## 2025-10-08
+
+* feat: Add `http-proxy` integration to Paas-charm.
+
 ## 1.9.0 - 2025-10-07
 
 * feat: Add profiles configuration option to Spring Boot.

--- a/examples/django/charm/charmcraft.yaml
+++ b/examples/django/charm/charmcraft.yaml
@@ -42,6 +42,8 @@ charm-libs:
   version: '0'
 - lib: hydra.oauth
   version: '0'
+- lib: squid_forward_proxy.http_proxy
+  version: '0'
 
 actions:
   rotate-secret-key:
@@ -144,6 +146,10 @@ requires:
     limit: 1
   oidc:
     interface: oauth
+    optional: True
+    limit: 1
+  http-proxy:
+    interface: http_proxy
     optional: True
     limit: 1
 

--- a/examples/expressjs/charm/charmcraft.yaml
+++ b/examples/expressjs/charm/charmcraft.yaml
@@ -39,6 +39,8 @@ charm-libs:
   version: '0'
 - lib: hydra.oauth
   version: '0'
+- lib: squid_forward_proxy.http_proxy
+  version: '0'
 
 actions:
   rotate-secret-key:
@@ -125,6 +127,10 @@ requires:
     limit: 1
   oidc:
     interface: oauth
+    optional: True
+    limit: 1
+  http-proxy:
+    interface: http_proxy
     optional: True
     limit: 1
 

--- a/examples/fastapi/charm/charmcraft.yaml
+++ b/examples/fastapi/charm/charmcraft.yaml
@@ -39,7 +39,9 @@ charm-libs:
   version: '0'
 - lib: hydra.oauth
   version: '0'
-
+- lib: squid_forward_proxy.http_proxy
+  version: '0'
+  
 actions:
   rotate-secret-key:
     description: Rotate the secret key. Users will be forced to log in again.
@@ -134,6 +136,10 @@ requires:
     limit: 1
   oidc:
     interface: oauth
+    optional: True
+    limit: 1
+  http-proxy:
+    interface: http_proxy
     optional: True
     limit: 1
 

--- a/examples/flask/charm/charmcraft.yaml
+++ b/examples/flask/charm/charmcraft.yaml
@@ -33,6 +33,8 @@ charm-libs:
   version: '0'
 - lib: hydra.oauth
   version: '0'
+- lib: squid_forward_proxy.http_proxy
+  version: '0'
 
 actions:
   rotate-secret-key:
@@ -184,6 +186,10 @@ requires:
     limit: 1
   oidc:
     interface: oauth
+    optional: True
+    limit: 1
+  http-proxy:
+    interface: http_proxy
     optional: True
     limit: 1
 

--- a/examples/go/charm/charmcraft.yaml
+++ b/examples/go/charm/charmcraft.yaml
@@ -39,6 +39,8 @@ charm-libs:
   version: '0'
 - lib: hydra.oauth
   version: '0'
+- lib: squid_forward_proxy.http_proxy
+  version: '0'
 
 actions:
   rotate-secret-key:
@@ -121,6 +123,10 @@ requires:
     limit: 1
   oidc:
     interface: oauth
+    optional: True
+    limit: 1
+  http-proxy:
+    interface: http_proxy
     optional: True
     limit: 1
 

--- a/examples/springboot/charm/charmcraft.yaml
+++ b/examples/springboot/charm/charmcraft.yaml
@@ -39,6 +39,8 @@ charm-libs:
   version: '0'
 - lib: hydra.oauth
   version: '0'
+- lib: squid_forward_proxy.http_proxy
+  version: '0'
 
 actions:
   rotate-secret-key:
@@ -149,6 +151,10 @@ requires:
     limit: 1
   tracing:
     interface: tracing
+    optional: True
+    limit: 1
+  http-proxy:
+    interface: http_proxy
     optional: True
     limit: 1
 resources:

--- a/src/paas_charm/__init__.py
+++ b/src/paas_charm/__init__.py
@@ -58,3 +58,10 @@ except ImportError as import_error:
     raise exceptions.MissingCharmLibraryError(
         "Missing charm library, please run `charmcraft fetch-lib charms.redis_k8s.v0.redis`"
     ) from import_error
+try:
+    import charms.squid_forward_proxy.v0.http_proxy  # noqa: F401
+except ImportError as import_error:
+    raise exceptions.MissingCharmLibraryError(
+        "Missing charm library, please run `charmcraft fetch-lib "
+        "charms.squid_forward_proxy.v0.http_proxy`"
+    ) from import_error

--- a/src/paas_charm/charm_utils.py
+++ b/src/paas_charm/charm_utils.py
@@ -9,7 +9,7 @@ from functools import wraps
 import ops
 
 from paas_charm.charm_state import CharmState
-from paas_charm.exceptions import CharmConfigInvalidError
+from paas_charm.exceptions import CharmConfigInvalidError, RelationDataUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +61,10 @@ def block_if_invalid_config(
         except CharmConfigInvalidError as exc:
             logger.exception("Wrong Charm Configuration")
             instance.update_app_and_unit_status(ops.BlockedStatus(exc.msg))
+            return None
+        except RelationDataUnavailableError as exc:
+            logger.exception("Relation data unavailable.")
+            instance.update_app_and_unit_status(ops.BlockedStatus(str(exc)))
             return None
 
     return wrapper

--- a/src/paas_charm/exceptions.py
+++ b/src/paas_charm/exceptions.py
@@ -36,3 +36,7 @@ class InvalidRelationDataError(Exception):
     """
 
     relation: str
+
+
+class RelationDataUnavailableError(Exception):
+    """Raised when relation data is unavailable."""

--- a/tests/unit/general/test_http_proxy.py
+++ b/tests/unit/general/test_http_proxy.py
@@ -1,0 +1,177 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Charm unit tests for the http-proxy relation."""
+
+import pathlib
+
+import pytest
+from charms.squid_forward_proxy.v0.http_proxy import HTTPProxyUnavailableError, ProxyConfig
+from ops import testing
+
+from examples.django.charm.src.charm import DjangoCharm
+from examples.expressjs.charm.src.charm import ExpressJSCharm
+from examples.fastapi.charm.src.charm import FastAPICharm
+from examples.flask.charm.src.charm import FlaskCharm
+from examples.go.charm.src.charm import GoCharm
+from examples.springboot.charm.src.charm import SpringBootCharm
+from paas_charm.app import App, WorkloadConfig
+from paas_charm.charm_state import CharmState, IntegrationsState
+
+
+@pytest.mark.parametrize(
+    "framework_name, container_fixture_name",
+    [
+        pytest.param("django", "django_container_mock", id="django"),
+        pytest.param("flask", "flask_container_mock", id="flask"),
+        pytest.param("go", "go_container_mock", id="go"),
+        pytest.param("springboot", "springboot_container_mock", id="springboot"),
+        pytest.param("fastapi", "fastapi_container_mock", id="fastapi"),
+        pytest.param("expressjs", "expressjs_container_mock", id="expressjs"),
+    ],
+)
+@pytest.mark.parametrize(
+    "set_env, integrations, expected",
+    [
+        pytest.param(
+            {
+                "JUJU_CHARM_HTTP_PROXY": "http://proxy.test",
+                "JUJU_CHARM_HTTPS_PROXY": "http://proxy.test",
+                "JUJU_CHARM_NO_PROXY": "127.0.0.1,localhost,::1",
+            },
+            None,
+            {
+                "APP_SECRET_KEY": "foobar",
+                "APP_BASE_URL": "https://paas.example.com",
+                "HTTP_PROXY": "http://proxy.test",
+                "HTTPS_PROXY": "http://proxy.test",
+                "NO_PROXY": "127.0.0.1,localhost,::1",
+                "http_proxy": "http://proxy.test",
+                "https_proxy": "http://proxy.test",
+                "no_proxy": "127.0.0.1,localhost,::1",
+            },
+            id="no http proxy relation",
+        ),
+        pytest.param(
+            {
+                "JUJU_CHARM_HTTP_PROXY": "http://proxy.test",
+                "JUJU_CHARM_HTTPS_PROXY": "http://proxy.test",
+                "JUJU_CHARM_NO_PROXY": "127.0.0.1,localhost,::1",
+            },
+            IntegrationsState(
+                http_proxy=ProxyConfig(
+                    http_proxy="http://squid.internal:3128",
+                    https_proxy="http://squid.internal:3128",
+                )
+            ),
+            {
+                "APP_SECRET_KEY": "foobar",
+                "APP_BASE_URL": "https://paas.example.com",
+                "HTTP_PROXY": "http://squid.internal:3128",
+                "HTTPS_PROXY": "http://squid.internal:3128",
+                "NO_PROXY": "127.0.0.1,localhost,::1",
+                "http_proxy": "http://squid.internal:3128",
+                "https_proxy": "http://squid.internal:3128",
+                "no_proxy": "127.0.0.1,localhost,::1",
+            },
+            id="with http proxy relation",
+        ),
+    ],
+)
+def test_http_proxy(
+    request,
+    monkeypatch,
+    framework_name,
+    container_fixture_name,
+    set_env,
+    integrations,
+    expected,
+    database_migration_mock,
+):
+    """
+    arrange: set juju charm generic app with and without http-proxy relation.
+    act: generate an environment.
+    assert: environment generated should contain proper proxy environment variables.
+    """
+    container_mock = request.getfixturevalue(container_fixture_name)
+    for set_env_name, set_env_value in set_env.items():
+        monkeypatch.setenv(set_env_name, set_env_value)
+
+    base_dir = pathlib.Path("/app")
+    workload_config = WorkloadConfig(
+        framework=framework_name,
+        container_name="app",
+        port=8080,
+        base_dir=base_dir,
+        app_dir=base_dir,
+        state_dir=base_dir / "state",
+        service_name=framework_name,
+        log_files=[],
+        unit_name=f"{framework_name}/0",
+    )
+
+    charm_state = CharmState(
+        framework=framework_name,
+        secret_key="foobar",
+        is_secret_storage_ready=True,
+        framework_config={},
+        base_url="https://paas.example.com",
+        user_defined_config={},
+        integrations=integrations,
+    )
+
+    app = App(
+        container=container_mock,
+        charm_state=charm_state,
+        workload_config=workload_config,
+        database_migration=database_migration_mock,
+        framework_config_prefix="",
+    )
+    env = app.gen_environment()
+    assert env == expected
+
+
+@pytest.mark.skip_http_proxy_response_patch
+@pytest.mark.parametrize(
+    "base_state, charm, config",
+    [
+        pytest.param("flask_base_state", FlaskCharm, {}, id="flask"),
+        pytest.param("django_base_state", DjangoCharm, {}, id="django"),
+        pytest.param(
+            "fastapi_base_state",
+            FastAPICharm,
+            {
+                "non-optional-string": "test",
+            },
+            id="fastapi",
+        ),
+        pytest.param("spring_boot_base_state", SpringBootCharm, {}, id="spring-boot"),
+        pytest.param("go_base_state", GoCharm, {}, id="go"),
+        pytest.param("expressjs_base_state", ExpressJSCharm, {}, id="expressjs"),
+    ],
+)
+def test_blocked_status_when_proxy_unavailable(
+    base_state: dict, charm, config: dict, request
+) -> None:
+    """
+    arrange: set the base state and add an empty http proxy relation.
+    act: Run a config changed hook.
+    assert: Workload charm should be blocked due to proxy values being unavailable.
+    """
+
+    base_state = request.getfixturevalue(base_state)
+    base_state["config"] = config
+    http_proxy_relation = testing.Relation(
+        endpoint="http-proxy",
+        interface="http_proxy",
+        remote_app_data={},
+    )
+    base_state["relations"].append(http_proxy_relation)
+
+    state = testing.State(**base_state)
+    context = testing.Context(
+        charm_type=charm,
+    )
+    out = context.run(context.on.config_changed(), state)
+
+    assert out.unit_status == testing.BlockedStatus("HTTP Proxy relation data unavailable.")

--- a/tests/unit/springboot/constants.py
+++ b/tests/unit/springboot/constants.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+DEFAULT_LAYER = {
+    "services": {
+        "spring-boot": {
+            "startup": "enabled",
+            "override": "replace",
+            "command": 'bash -c "java -jar *.jar"',
+        },
+    }
+}
+
+SPRINGBOOT_CONTAINER_NAME = "app"

--- a/tests/unit/test_charm/charmcraft.yaml
+++ b/tests/unit/test_charm/charmcraft.yaml
@@ -79,6 +79,10 @@ requires:
     interface: tracing
     optional: True
     limit: 1
+  http-proxy:
+    interface: http_proxy
+    optional: True
+    limit: 1
 resources:
   test-app-image:
     description: testomg application image.


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The RTD documentation is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
