### PR TITLE
Add configuration_prefix attribute

### DIFF
--- a/examples/django/charm/charmcraft.yaml
+++ b/examples/django/charm/charmcraft.yaml
@@ -110,6 +110,9 @@ config:
       type: string
       description: A list of scopes with spaces in between.
       default: "openid profile email"
+    user-defined-config:
+      type: string
+      description: Example of a user defined configuration.
 
 containers:
   django-app:

--- a/examples/flask/charm/charmcraft.yaml
+++ b/examples/flask/charm/charmcraft.yaml
@@ -126,6 +126,9 @@ config:
       type: string
       description: A list of scopes with spaces in between.
       default: "openid profile email"
+    user-defined-config:
+      type: string
+      description: Example of a user defined configuration.
 
 containers:
   flask-app:

--- a/src/paas_charm/_gunicorn/charm.py
+++ b/src/paas_charm/_gunicorn/charm.py
@@ -92,6 +92,7 @@ class GunicornBase(PaasCharm):
             workload_config=self._workload_config,
             webserver=webserver,
             database_migration=self._database_migration,
+            configuration_prefix=self.configuration_prefix,
         )
 
     def _check_gevent_package(self) -> bool:

--- a/src/paas_charm/_gunicorn/wsgi_app.py
+++ b/src/paas_charm/_gunicorn/wsgi_app.py
@@ -28,6 +28,8 @@ class WsgiApp(App):
         workload_config: WorkloadConfig,
         database_migration: DatabaseMigration,
         webserver: GunicornWebserver,
+        configuration_prefix: str | None = None,
+        framework_config_prefix: str | None = None,
     ):
         """Construct the WsgiApp instance.
 
@@ -47,8 +49,8 @@ class WsgiApp(App):
             charm_state=charm_state,
             workload_config=workload_config,
             database_migration=database_migration,
-            configuration_prefix=f"{workload_config.framework.upper()}_",
-            framework_config_prefix=f"{workload_config.framework.upper()}_",
+            configuration_prefix=configuration_prefix,
+            framework_config_prefix=framework_config_prefix,
         )
         self._webserver = webserver
 

--- a/src/paas_charm/charm.py
+++ b/src/paas_charm/charm.py
@@ -105,6 +105,7 @@ class PaasCharm(abc.ABC, ops.CharmBase):  # pylint: disable=too-many-instance-at
     """
 
     framework_config_class: type[BaseModel]
+    configuration_prefix = "APP_"
 
     @property
     @abc.abstractmethod

--- a/src/paas_charm/django/charm.py
+++ b/src/paas_charm/django/charm.py
@@ -57,6 +57,7 @@ class Charm(GunicornBase):
     """
 
     framework_config_class = DjangoConfig
+    configuration_prefix = "DJANGO_"
 
     def __init__(self, framework: ops.Framework) -> None:
         """Initialize the Django charm.

--- a/src/paas_charm/expressjs/charm.py
+++ b/src/paas_charm/expressjs/charm.py
@@ -85,4 +85,5 @@ class Charm(PaasCharm):
             workload_config=self._workload_config,
             database_migration=self._database_migration,
             framework_config_prefix="",
+            configuration_prefix=self.configuration_prefix,
         )

--- a/src/paas_charm/fastapi/charm.py
+++ b/src/paas_charm/fastapi/charm.py
@@ -91,4 +91,5 @@ class Charm(PaasCharm):
             workload_config=self._workload_config,
             database_migration=self._database_migration,
             framework_config_prefix="",
+            configuration_prefix=self.configuration_prefix,
         )

--- a/src/paas_charm/flask/charm.py
+++ b/src/paas_charm/flask/charm.py
@@ -68,6 +68,7 @@ class Charm(GunicornBase):
     """
 
     framework_config_class = FlaskConfig
+    configuration_prefix = "FLASK_"
 
     def __init__(self, framework: ops.Framework) -> None:
         """Initialize the Flask charm.

--- a/src/paas_charm/go/charm.py
+++ b/src/paas_charm/go/charm.py
@@ -82,4 +82,5 @@ class Charm(PaasCharm):
             charm_state=charm_state,
             workload_config=self._workload_config,
             database_migration=self._database_migration,
+            configuration_prefix=self.configuration_prefix,
         )

--- a/src/paas_charm/springboot/charm.py
+++ b/src/paas_charm/springboot/charm.py
@@ -435,6 +435,7 @@ class Charm(PaasCharm):
             workload_config=self._workload_config,
             database_migration=self._database_migration,
             framework_config_prefix="",
+            configuration_prefix=self.configuration_prefix,
         )
 
     def get_cos_dir(self) -> str:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Having the legacy `APP_` prefix in environment variables generated from the user-defined config options makes it harder for our customers to use the paas-charm library when charming applications. In this PR we are introducing `configuration_prefix` attribute to let our users customize the prefix.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The RTD documentation is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
