### PR TITLE
Modify the default Grafana log query to not have empty values

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
+* fix: Fix bug in the Grafana Dashboards of Django, Express, FastAPI and Flask
+where when all the variables hold the value `All` (which it does in default), Loki
+throws an error.
+
 ## 2025-11-19
 
 * chore: Update Express grafana dashboard.

--- a/src/paas_charm/django/cos/grafana_dashboards/django.json
+++ b/src/paas_charm/django/cos/grafana_dashboards/django.json
@@ -839,7 +839,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} |= ``",
+          "expr": "{juju_application=~\"$juju_application\",juju_application!=``,juju_model=~\"$juju_model\",juju_model!=``,juju_model_uuid=~\"$juju_model_uuid\",juju_model_uuid!=``,juju_unit=~\"$juju_unit\",juju_unit!=``} |= ``",
           "queryType": "range",
           "refId": "A"
         }

--- a/src/paas_charm/expressjs/cos/grafana_dashboards/expressjs.json
+++ b/src/paas_charm/expressjs/cos/grafana_dashboards/expressjs.json
@@ -649,7 +649,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} |= ``",
+          "expr": "{juju_application=~\"$juju_application\",juju_application!=``,juju_model=~\"$juju_model\",juju_model!=``,juju_model_uuid=~\"$juju_model_uuid\",juju_model_uuid!=``,juju_unit=~\"$juju_unit\",juju_unit!=``} |= ``",
           "queryType": "range",
           "refId": "A"
         }

--- a/src/paas_charm/fastapi/cos/grafana_dashboards/fastapi.json
+++ b/src/paas_charm/fastapi/cos/grafana_dashboards/fastapi.json
@@ -649,7 +649,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} |= ``",
+          "expr": "{juju_application=~\"$juju_application\",juju_application!=``,juju_model=~\"$juju_model\",juju_model!=``,juju_model_uuid=~\"$juju_model_uuid\",juju_model_uuid!=``,juju_unit=~\"$juju_unit\",juju_unit!=``} |= ``",
           "queryType": "range",
           "refId": "A"
         }

--- a/src/paas_charm/flask/cos/grafana_dashboards/flask.json
+++ b/src/paas_charm/flask/cos/grafana_dashboards/flask.json
@@ -839,7 +839,7 @@
             "uid": "${lokids}"
           },
           "editorMode": "builder",
-          "expr": "{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} |= ``",
+          "expr": "{juju_application=~\"$juju_application\",juju_application!=``,juju_model=~\"$juju_model\",juju_model!=``,juju_model_uuid=~\"$juju_model_uuid\",juju_model_uuid!=``,juju_unit=~\"$juju_unit\",juju_unit!=``} |= ``",
           "queryType": "range",
           "refId": "A"
         }


### PR DESCRIPTION

The fix is simple and is actually already implemented in `grafana_dashboards/spring_boot.json` file: at least a single condition that cannot be empty. My commit does a similar change by making all the variables in the query such as `juju_application` expect to be non-empty explicitly. Making this change to only a single variable would also be sufficient, but I decided to make it explicit.

Applicable spec: <link>

### Overview
Changes to the grafana dashboard's loki queries for the cases where `All` is selected for all four variables in grafana.

### Rationale
Loki queries are limitted to at least one `non-empty` conditional, but since the current query in the default Application logs dashboard uses variables that have `.*` regex as their `All` value, they are capable to become fully empty when `All` is selected. And since loki dislikes this possibilty it throws an error whenever all the variables are chosen to be `All` which is also the first thing we see when we enter the dashboard.


### Juju Events Changes
None

### Module Changes
None

### Library Changes
None

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The RTD documentation is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
