### PR TITLE
feat: Add paas-config.yaml file reading infrastructure

### DIFF
--- a/examples/flask/charm/paas-config.yaml
+++ b/examples/flask/charm/paas-config.yaml
@@ -1,0 +1,8 @@
+version: "1"
+prometheus:
+  scrape_configs:
+    - job_name: "example-job"
+      metrics_path: "/metrics"
+      static_configs:
+        - targets:
+          - "*:8080"

--- a/examples/flask/charm/paas-config.yaml
+++ b/examples/flask/charm/paas-config.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 version: "1"
 prometheus:
   scrape_configs:

--- a/src/paas_charm/charm_state.py
+++ b/src/paas_charm/charm_state.py
@@ -16,6 +16,7 @@ from paas_charm.exceptions import (
     InvalidRelationDataError,
     RelationDataError,
 )
+from paas_charm.paas_config import PaasConfig, read_paas_config
 from paas_charm.secret_storage import KeySecretStorage
 from paas_charm.utils import build_validation_error_message, config_metadata
 
@@ -47,6 +48,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         secret_key: the charm managed application secret key.
         is_secret_storage_ready: whether the secret storage system is ready.
         proxy: proxy information.
+        paas_config: configuration from paas-config.yaml file if present.
     """
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -60,6 +62,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         peer_fqdns: str | None = None,
         integrations: "IntegrationsState | None" = None,
         base_url: str | None = None,
+        paas_config: PaasConfig | None = None,
     ):
         """Initialize a new instance of the CharmState class.
 
@@ -72,6 +75,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             peer_fqdns: The FQDN of units in the peer relation.
             integrations: Information about the integrations.
             base_url: Base URL for the service.
+            paas_config: Configuration from paas-config.yaml file.
         """
         self.framework = framework
         self._framework_config = framework_config if framework_config is not None else {}
@@ -81,6 +85,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         self.peer_fqdns = peer_fqdns
         self.integrations = integrations or IntegrationsState()
         self.base_url = base_url
+        self.paas_config = paas_config
 
     @classmethod
     def from_charm(  # pylint: disable=too-many-arguments,too-many-locals
@@ -210,6 +215,9 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
         ):
             peer_fqdns = ",".join(peer_unit_fqdns)
 
+        # Read paas-config.yaml file if present
+        paas_config = read_paas_config()
+
         return cls(
             framework=framework,
             framework_config=framework_config.model_dump(exclude_none=True),
@@ -223,6 +231,7 @@ class CharmState:  # pylint: disable=too-many-instance-attributes
             peer_fqdns=peer_fqdns,
             integrations=integrations,
             base_url=base_url,
+            paas_config=paas_config,
         )
 
     @property

--- a/src/paas_charm/paas_config.py
+++ b/src/paas_charm/paas_config.py
@@ -1,0 +1,109 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Module for reading and validating the paas-config.yaml configuration file."""
+
+import logging
+import pathlib
+import typing
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from paas_charm.exceptions import CharmConfigInvalidError
+from paas_charm.utils import build_validation_error_message
+
+logger = logging.getLogger(__name__)
+
+CONFIG_FILE_NAME = "paas-config.yaml"
+
+
+class PaasConfig(BaseModel):
+    """Configuration from paas-config.yaml file.
+
+    Attributes:
+        version: Configuration file schema version.
+        prometheus: Prometheus-related configuration (reserved for future use).
+        http_proxy: HTTP proxy configuration (reserved for future use).
+    """
+
+    version: str = Field(description="Configuration file schema version")
+    prometheus: typing.Dict[str, typing.Any] | None = Field(
+        default=None, description="Prometheus configuration (reserved for future use)"
+    )
+    http_proxy: typing.Dict[str, typing.Any] | None = Field(
+        default=None,
+        alias="http-proxy",
+        description="HTTP proxy configuration (reserved for future use)",
+    )
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    @field_validator("version")
+    @classmethod
+    def validate_version(cls, value: str) -> str:
+        """Validate the version field.
+
+        Args:
+            value: The version string to validate.
+
+        Returns:
+            The validated version string.
+
+        Raises:
+            ValueError: If the version is not supported.
+        """
+        supported_versions = {"1"}
+        if value not in supported_versions:
+            raise ValueError(
+                f"Unsupported paas-config.yaml version: {value}. "
+                f"Supported versions: {', '.join(sorted(supported_versions))}"
+            )
+        return value
+
+
+def read_paas_config(charm_root: pathlib.Path | None = None) -> PaasConfig | None:
+    """Read and validate the paas-config.yaml file.
+
+    Args:
+        charm_root: Path to the charm root directory. If None, uses current directory.
+
+    Returns:
+        PaasConfig object if file exists and is valid, None if file doesn't exist.
+
+    Raises:
+        CharmConfigInvalidError: If the file exists but is invalid (malformed YAML
+            or schema validation error).
+    """
+    if charm_root is None:
+        charm_root = pathlib.Path.cwd()
+
+    config_path = charm_root / CONFIG_FILE_NAME
+
+    if not config_path.exists():
+        logger.info("No %s file found, using default configuration", CONFIG_FILE_NAME)
+        return None
+
+    try:
+        with config_path.open("r", encoding="utf-8") as config_file:
+            config_data = yaml.safe_load(config_file)
+    except yaml.YAMLError as exc:
+        error_msg = f"Invalid YAML in {CONFIG_FILE_NAME}: {exc}"
+        logger.error(error_msg)
+        raise CharmConfigInvalidError(error_msg) from exc
+    except (OSError, IOError) as exc:
+        error_msg = f"Failed to read {CONFIG_FILE_NAME}: {exc}"
+        logger.error(error_msg)
+        raise CharmConfigInvalidError(error_msg) from exc
+
+    if config_data is None:
+        logger.warning("%s file is empty, using default configuration", CONFIG_FILE_NAME)
+        return None
+
+    try:
+        return PaasConfig(**config_data)
+    except ValidationError as exc:
+        error_details = build_validation_error_message(exc, underscore_to_dash=True)
+        error_msg = f"Invalid {CONFIG_FILE_NAME}: {error_details.short}"
+        logger.error("%s: %s", error_msg, error_details.long)
+        raise CharmConfigInvalidError(error_msg) from exc

--- a/src/paas_charm/paas_config.py
+++ b/src/paas_charm/paas_config.py
@@ -25,6 +25,7 @@ class PaasConfig(BaseModel):
         version: Configuration file schema version.
         prometheus: Prometheus-related configuration (reserved for future use).
         http_proxy: HTTP proxy configuration (reserved for future use).
+        model_config: Pydantic model configuration.
     """
 
     version: str = Field(description="Configuration file schema version")

--- a/tests/unit/general/test_paas_config.py
+++ b/tests/unit/general/test_paas_config.py
@@ -1,0 +1,202 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for paas_config module."""
+
+import pathlib
+import tempfile
+from unittest.mock import patch
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from paas_charm.exceptions import CharmConfigInvalidError
+from paas_charm.paas_config import CONFIG_FILE_NAME, PaasConfig, read_paas_config
+
+
+class TestPaasConfig:
+    """Tests for PaasConfig Pydantic model."""
+
+    def test_valid_config_minimal(self):
+        """Test valid minimal configuration with only version."""
+        config = PaasConfig(version="1")
+        assert config.version == "1"
+        assert config.prometheus is None
+        assert config.http_proxy is None
+
+    def test_valid_config_with_prometheus(self):
+        """Test valid configuration with prometheus section."""
+        config = PaasConfig(
+            version="1",
+            prometheus={"scrape_configs": [{"job_name": "test"}]},
+        )
+        assert config.version == "1"
+        assert config.prometheus == {"scrape_configs": [{"job_name": "test"}]}
+
+    def test_valid_config_with_http_proxy_snake_case(self):
+        """Test valid configuration with http_proxy in snake_case."""
+        config = PaasConfig(version="1", http_proxy={"domains": ["example.com"]})
+        assert config.version == "1"
+        assert config.http_proxy == {"domains": ["example.com"]}
+
+    def test_valid_config_with_http_proxy_kebab_case(self):
+        """Test valid configuration with http-proxy in kebab-case (alias)."""
+        config_data = {"version": "1", "http-proxy": {"domains": ["example.com"]}}
+        config = PaasConfig(**config_data)
+        assert config.version == "1"
+        assert config.http_proxy == {"domains": ["example.com"]}
+
+    def test_missing_version(self):
+        """Test that version field is required."""
+        with pytest.raises(ValidationError) as exc_info:
+            PaasConfig()
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("version",)
+        assert "required" in errors[0]["msg"].lower()
+
+    def test_unsupported_version(self):
+        """Test that unsupported version raises validation error."""
+        with pytest.raises(ValidationError) as exc_info:
+            PaasConfig(version="2")
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert "unsupported" in errors[0]["msg"].lower()
+
+    def test_extra_fields_forbidden(self):
+        """Test that extra fields are not allowed."""
+        with pytest.raises(ValidationError) as exc_info:
+            PaasConfig(version="1", unknown_field="value")
+        errors = exc_info.value.errors()
+        assert any("extra" in str(error["type"]).lower() for error in errors)
+
+    def test_invalid_version_type(self):
+        """Test that version must be a string."""
+        with pytest.raises(ValidationError) as exc_info:
+            PaasConfig(version=1)
+        errors = exc_info.value.errors()
+        assert len(errors) == 1
+        assert errors[0]["loc"] == ("version",)
+
+
+class TestReadPaasConfig:
+    """Tests for read_paas_config function."""
+
+    def test_missing_file_returns_none(self, tmp_path):
+        """Test that missing config file returns None."""
+        config = read_paas_config(tmp_path)
+        assert config is None
+
+    def test_valid_config_file(self, tmp_path):
+        """Test reading a valid config file."""
+        config_path = tmp_path / CONFIG_FILE_NAME
+        config_data = {"version": "1", "prometheus": {"scrape_configs": []}}
+        with config_path.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        config = read_paas_config(tmp_path)
+        assert config is not None
+        assert config.version == "1"
+        assert config.prometheus == {"scrape_configs": []}
+
+    def test_empty_file_returns_none(self, tmp_path):
+        """Test that empty config file returns None."""
+        config_path = tmp_path / CONFIG_FILE_NAME
+        config_path.touch()
+
+        config = read_paas_config(tmp_path)
+        assert config is None
+
+    def test_file_with_only_whitespace_returns_none(self, tmp_path):
+        """Test that file with only whitespace returns None."""
+        config_path = tmp_path / CONFIG_FILE_NAME
+        with config_path.open("w", encoding="utf-8") as f:
+            f.write("   \n\n   \n")
+
+        config = read_paas_config(tmp_path)
+        assert config is None
+
+    def test_invalid_yaml_raises_error(self, tmp_path):
+        """Test that invalid YAML raises CharmConfigInvalidError."""
+        config_path = tmp_path / CONFIG_FILE_NAME
+        with config_path.open("w", encoding="utf-8") as f:
+            f.write("version: 1\n  invalid: yaml: content")
+
+        with pytest.raises(CharmConfigInvalidError) as exc_info:
+            read_paas_config(tmp_path)
+        assert "Invalid YAML" in str(exc_info.value)
+
+    def test_invalid_schema_raises_error(self, tmp_path):
+        """Test that schema validation error raises CharmConfigInvalidError."""
+        config_path = tmp_path / CONFIG_FILE_NAME
+        config_data = {"version": "99", "unknown_key": "value"}
+        with config_path.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        with pytest.raises(CharmConfigInvalidError) as exc_info:
+            read_paas_config(tmp_path)
+        assert "Invalid" in str(exc_info.value)
+
+    def test_missing_version_field_raises_error(self, tmp_path):
+        """Test that missing version field raises CharmConfigInvalidError."""
+        config_path = tmp_path / CONFIG_FILE_NAME
+        config_data = {"prometheus": {}}
+        with config_path.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        with pytest.raises(CharmConfigInvalidError) as exc_info:
+            read_paas_config(tmp_path)
+        assert "Invalid" in str(exc_info.value)
+
+    def test_file_read_error_raises_error(self, tmp_path):
+        """Test that file read error raises CharmConfigInvalidError."""
+        config_path = tmp_path / CONFIG_FILE_NAME
+        config_path.touch(mode=0o000)  # No read permissions
+
+        try:
+            with pytest.raises(CharmConfigInvalidError) as exc_info:
+                read_paas_config(tmp_path)
+            assert "Failed to read" in str(exc_info.value)
+        finally:
+            config_path.chmod(0o644)  # Restore permissions for cleanup
+
+    def test_default_charm_root_uses_cwd(self):
+        """Test that None charm_root uses current working directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = pathlib.Path(tmpdir)
+            config_path = tmp_path / CONFIG_FILE_NAME
+            config_data = {"version": "1"}
+            with config_path.open("w", encoding="utf-8") as f:
+                yaml.dump(config_data, f)
+
+            with patch("pathlib.Path.cwd", return_value=tmp_path):
+                config = read_paas_config()
+                assert config is not None
+                assert config.version == "1"
+
+    def test_config_with_all_fields(self, tmp_path):
+        """Test reading a config file with all supported fields."""
+        config_path = tmp_path / CONFIG_FILE_NAME
+        config_data = {
+            "version": "1",
+            "prometheus": {
+                "scrape_configs": [
+                    {
+                        "job_name": "job1",
+                        "metrics_path": "/metrics",
+                        "static_configs": [{"targets": ["*:8080"]}],
+                    }
+                ]
+            },
+            "http-proxy": {"domains": ["api.example.com"]},
+        }
+        with config_path.open("w", encoding="utf-8") as f:
+            yaml.dump(config_data, f)
+
+        config = read_paas_config(tmp_path)
+        assert config is not None
+        assert config.version == "1"
+        assert config.prometheus is not None
+        assert config.http_proxy is not None
+        assert config.http_proxy == {"domains": ["api.example.com"]}

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ allowlist_externals =
     snap
     sudo
 commands =
-    sudo snap install charmcraft --classic --channel=latest/stable
+    sh -c 'snap list charmcraft || sudo snap install charmcraft --classic --channel=latest/stable'
     sh -c 'for d in {toxinidir}/examples/*/charm; do if [ -d "$d" ]; then (cd "$d" && charmcraft fetch-libs); fi; done'
     codespell {toxinidir} \
       --skip {toxinidir}/.git \
@@ -107,7 +107,7 @@ allowlist_externals =
     snap
     sudo
 commands =
-    sudo snap install charmcraft --classic --channel=latest/stable
+    sh -c 'snap list charmcraft || sudo snap install charmcraft --classic --channel=latest/stable'
     sh -c 'for d in {toxinidir}/examples/*/charm; do if [ -d "$d" ]; then (cd "$d" && charmcraft fetch-libs); fi; done'
     coverage run --source={[vars]src_path},{[vars]legacy_src_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}


### PR DESCRIPTION
- Add new paas_config.py module with PaasConfig Pydantic model
- Support version validation (currently only version '1')
- Add placeholders for future features (prometheus, http-proxy)
- Integrate with CharmState to read config on initialization
- Add comprehensive unit tests (18 tests, all passing)
- Add example paas-config.yaml to flask charm
- Handle missing file gracefully (returns None)
- Raise CharmConfigInvalidError for invalid YAML or schema violations

Implements ISD266 specification for 12-factor configuration file.

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The RTD documentation is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The [changelog](../docs/changelog.md) is updated with user-relevant changes in the format of [keep a changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)

<!-- Explanation for any unchecked items above -->
