### PR TITLE
chore: Fix integration tests

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Place any unreleased changes here, that are subject to release in coming versions :).
 
-
 ## 1.11.1 - 2026-03-17
 
 * fix: Fix an issue where the custom COS directory was merged on all events instead of just once.

--- a/tests/integration/flask/test_charm.py
+++ b/tests/integration/flask/test_charm.py
@@ -269,7 +269,7 @@ def test_app_peer_address(
     """
     # Add a unit
     juju.add_unit(flask_app.name)
-    juju.wait(lambda status: status.apps[flask_app.name].is_active, successes=5, delay=5)
+    juju.wait(lambda status: jubilant.all_active(status, flask_app.name), successes=5, delay=5)
 
     status = juju.status()
     model_name = status.model.name
@@ -298,7 +298,7 @@ def test_app_peer_address(
 
     # Scale back to 1 unit
     juju.remove_unit(flask_app.name, num_units=1)
-    juju.wait(lambda status: status.apps[flask_app.name].is_active, successes=5, delay=5)
+    juju.wait(lambda status: jubilant.all_active(status, flask_app.name), successes=5, delay=5)
     status = juju.status()
     for unit in status.apps[flask_app.name].units.values():
         check_peer_fqdns(unit, actual_result, is_in=False)


### PR DESCRIPTION
#### What this PR does

Fix integration test test_charm.py in Flask. The reason is that we should wait for all units to be active, not for the application.

#### Why we need it

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

