### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -195,7 +195,7 @@ def deploy_loki_fixture(
 ) -> App:
     """Deploy loki."""
     if not juju.status().apps.get(loki_app_name):
-        juju.deploy(loki_app_name, channel="1/stable", trust=True)
+        juju.deploy(loki_app_name, channel="1/stable", trust=True, log=False)
     juju.wait(
         lambda status: status.apps[loki_app_name].is_active,
         error=jubilant.any_blocked,
@@ -363,16 +363,14 @@ def expressjs_app_fixture(
             "plugin_hstore_enable": "true",
             "plugin_pg_trgm_enable": "true",
         },
+        log=False,
     )
 
     resources = {
         "app-image": pytestconfig.getoption("--expressjs-app-image"),
     }
     charm_file = build_charm_file(pytestconfig, "expressjs", tmp_path_factory)
-    juju.deploy(
-        charm=charm_file,
-        resources=resources,
-    )
+    juju.deploy(charm=charm_file, resources=resources, log=False)
 
     # Add required relations
     juju.integrate(app_name, "postgresql-k8s:database")
@@ -429,6 +427,7 @@ def spring_boot_app_fixture(
                 "plugin_hstore_enable": "true",
                 "plugin_pg_trgm_enable": "true",
             },
+            log=False,
         )
     except jubilant.CLIError as err:
         if "application already exists" not in err.stderr:
@@ -441,11 +440,7 @@ def spring_boot_app_fixture(
         charm_location=PROJECT_ROOT / "examples/springboot/charm",
     )
     try:
-        juju.deploy(
-            charm=charm_file,
-            app=app_name,
-            resources=resources,
-        )
+        juju.deploy(charm=charm_file, app=app_name, resources=resources, log=False)
     except jubilant.CLIError as err:
         if "application already exists" in err.stderr:
             juju.refresh(app_name, path=charm_file, resources=resources)
@@ -505,11 +500,7 @@ def spring_boot_mysql_app_fixture(
         charm_location=PROJECT_ROOT / "examples/springboot/charm",
     )
     try:
-        juju.deploy(
-            charm=charm_file,
-            app=app_name,
-            resources=resources,
-        )
+        juju.deploy(charm=charm_file, app=app_name, resources=resources, log=False)
     except jubilant.CLIError as err:
         if "application already exists" in err.stderr:
             juju.refresh(app_name, path=charm_file, resources=resources)
@@ -560,6 +551,7 @@ def deploy_traefik_fixture(
                 "external_hostname": external_hostname,
                 "routing_mode": "subdomain",
             },
+            log=False,
         )
     juju.wait(
         lambda status: status.apps[traefik_app_name].is_active,
@@ -573,7 +565,7 @@ def deploy_redis_k8s_jubilant_fixture(juju: jubilant.Juju):
     """Deploy Redis k8s charm using jubilant."""
     app_name = "redis-k8s"
     if not juju.status().apps.get(app_name):
-        juju.deploy(app_name, channel="edge")
+        juju.deploy(app_name, channel="edge", log=False)
     juju.wait(lambda status: status.apps[app_name].is_active, error=jubilant.any_blocked)
     return App(app_name)
 
@@ -681,10 +673,7 @@ def generate_app_fixture(
     )
     try:
         juju.deploy(
-            charm=charm_file,
-            app=f"{framework}-k8s",
-            resources=resources,
-            config=config,
+            charm=charm_file, app=f"{framework}-k8s", resources=resources, config=config, log=False
         )
     except jubilant.CLIError as err:
         if "application already exists" not in err.stderr:
@@ -723,6 +712,7 @@ def deploy_postgresql(
             "plugin_hstore_enable": "true",
             "plugin_pg_trgm_enable": "true",
         },
+        log=False,
     )
 
 
@@ -813,7 +803,7 @@ def flask_blocked_app_fixture(
     )
 
     try:
-        juju.deploy(charm=str(charm_file), app=app_name, resources=resources)
+        juju.deploy(charm=str(charm_file), app=app_name, resources=resources, log=False)
     except jubilant.CLIError as err:
         if "application already exists" not in err.stderr:
             raise err
@@ -846,6 +836,7 @@ def django_blocked_app_fixture(
             app=app_name,
             resources=resources,
             config={"django-allowed-hosts": "*"},
+            log=False,
         )
     except jubilant.CLIError as err:
         if "application already exists" not in err.stderr:
@@ -883,7 +874,7 @@ def fastapi_blocked_app_fixture(
     )
 
     try:
-        juju.deploy(charm=str(charm_file), app=app_name, resources=resources)
+        juju.deploy(charm=str(charm_file), app=app_name, resources=resources, log=False)
     except jubilant.CLIError as err:
         if "application already exists" not in err.stderr:
             raise err
@@ -920,7 +911,7 @@ def go_blocked_app_fixture(
     )
 
     try:
-        juju.deploy(charm=str(charm_file), app=app_name, resources=resources)
+        juju.deploy(charm=str(charm_file), app=app_name, resources=resources, log=False)
     except jubilant.CLIError as err:
         if "application already exists" not in err.stderr:
             raise err
@@ -957,7 +948,7 @@ def expressjs_blocked_app_fixture(
     )
 
     try:
-        juju.deploy(charm=str(charm_file), app=app_name, resources=resources)
+        juju.deploy(charm=str(charm_file), app=app_name, resources=resources, log=False)
     except jubilant.CLIError as err:
         if "application already exists" not in err.stderr:
             raise err

--- a/tests/integration/django/conftest.py
+++ b/tests/integration/django/conftest.py
@@ -27,10 +27,10 @@ def update_config(juju: jubilant.Juju, request: pytest.FixtureRequest, django_ap
     This fixture must be parameterized with changing charm configurations.
     """
     app_name = django_app.name
-    orig_config = juju.config(app_name)
+    orig_config = juju.config(app_name, log=False)
 
     request_config = {k: str(v) for k, v in request.param.items()}
-    juju.config(app_name, request_config)
+    juju.config(app_name, request_config, log=False)
     juju.wait(lambda status: jubilant.all_active(status, app_name))
 
     yield request_config
@@ -38,4 +38,4 @@ def update_config(juju: jubilant.Juju, request: pytest.FixtureRequest, django_ap
     # Restore original configuration
     restore_config = {k: str(v) for k, v in orig_config.items() if k in request_config}
     reset_config = [k for k in request_config if orig_config.get(k) is None]
-    juju.config(app_name, restore_config, reset=reset_config)
+    juju.config(app_name, restore_config, reset=reset_config, log=False)

--- a/tests/integration/django/test_workers.py
+++ b/tests/integration/django/test_workers.py
@@ -27,7 +27,7 @@ def test_async_workers(
     act: Do 15 requests that would take 2 seconds each.
     assert: All 15 requests should be served in under 3 seconds.
     """
-    juju.config(django_async_app.name, {"webserver-worker-class": "gevent"})
+    juju.config(django_async_app.name, {"webserver-worker-class": "gevent"}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, django_async_app.name), timeout=60)
 
     # the django unit is not important. Take the first one

--- a/tests/integration/expressjs/test_expressjs.py
+++ b/tests/integration/expressjs/test_expressjs.py
@@ -39,7 +39,7 @@ def test_user_defined_config(
     act: call the endpoint to get the value of the env variable related to the config.
     assert: the value of the env variable and the config should match.
     """
-    juju.config(expressjs_app.name, {"user-defined-config": "newvalue"})
+    juju.config(expressjs_app.name, {"user-defined-config": "newvalue"}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, expressjs_app.name, "postgresql-k8s"))
 
     status = juju.status()

--- a/tests/integration/fastapi/conftest.py
+++ b/tests/integration/fastapi/conftest.py
@@ -16,10 +16,10 @@ def update_config(juju: jubilant.Juju, request: pytest.FixtureRequest, fastapi_a
     This fixture must be parameterized with changing charm configurations.
     """
     app_name = fastapi_app.name
-    orig_config = juju.config(app_name)
+    orig_config = juju.config(app_name, log=False)
 
     request_config = {k: str(v) for k, v in request.param.items()}
-    juju.config(app_name, request_config)
+    juju.config(app_name, request_config, log=False)
     juju.wait(
         lambda status: status.apps[app_name].is_active or status.apps[app_name].is_blocked,
         successes=5,
@@ -31,4 +31,4 @@ def update_config(juju: jubilant.Juju, request: pytest.FixtureRequest, fastapi_a
     # Restore original configuration
     restore_config = {k: str(v) for k, v in orig_config.items() if k in request_config}
     reset_config = [k for k in request_config if orig_config.get(k) is None]
-    juju.config(app_name, restore_config, reset=reset_config)
+    juju.config(app_name, restore_config, reset=reset_config, log=False)

--- a/tests/integration/fastapi/test_fastapi.py
+++ b/tests/integration/fastapi/test_fastapi.py
@@ -35,7 +35,7 @@ def test_user_defined_config(fastapi_app: App, juju: jubilant.Juju):
     act: call the endpoint to get the value of the env variable related to the config.
     assert: the value of the env variable and the config should match.
     """
-    juju.config(fastapi_app.name, {"user-defined-config": "newvalue"})
+    juju.config(fastapi_app.name, {"user-defined-config": "newvalue"}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, fastapi_app.name, "postgresql-k8s"))
 
     status = juju.status()

--- a/tests/integration/flask/conftest.py
+++ b/tests/integration/flask/conftest.py
@@ -26,10 +26,10 @@ def update_config(juju: jubilant.Juju, request: pytest.FixtureRequest, flask_app
     This fixture must be parameterized with changing charm configurations.
     """
     app_name = flask_app.name
-    orig_config = juju.config(app_name)
+    orig_config = juju.config(app_name, log=False)
 
     request_config = {k: str(v) for k, v in request.param.items()}
-    juju.config(app_name, request_config)
+    juju.config(app_name, request_config, log=False)
     juju.wait(
         lambda status: status.apps[app_name].is_active or status.apps[app_name].is_blocked,
         successes=5,
@@ -41,7 +41,7 @@ def update_config(juju: jubilant.Juju, request: pytest.FixtureRequest, flask_app
     # Restore original configuration
     restore_config = {k: str(v) for k, v in orig_config.items() if k in request_config}
     reset_config = [k for k in request_config if orig_config.get(k) is None]
-    juju.config(app_name, restore_config, reset=reset_config)
+    juju.config(app_name, restore_config, reset=reset_config, log=False)
 
 
 @pytest.fixture(scope="function")
@@ -51,7 +51,7 @@ def update_secret_config(juju: jubilant.Juju, request: pytest.FixtureRequest, fl
     This fixture must be parameterized with changing charm configurations.
     """
     app_name = flask_app.name
-    orig_config = juju.config(app_name)
+    orig_config = juju.config(app_name, log=False)
     request_config = {}
     secret_ids = []
 
@@ -62,7 +62,7 @@ def update_secret_config(juju: jubilant.Juju, request: pytest.FixtureRequest, fl
         request_config[secret_config_option] = secret_id
         secret_ids.append(secret_id)
 
-    juju.config(app_name, request_config)
+    juju.config(app_name, request_config, log=False)
     juju.wait(lambda status: status.apps[app_name].is_active, successes=5, delay=10)
 
     yield request_config
@@ -70,7 +70,7 @@ def update_secret_config(juju: jubilant.Juju, request: pytest.FixtureRequest, fl
     # Restore original configuration
     restore_config = {k: str(v) for k, v in orig_config.items() if k in request_config}
     reset_config = [k for k in request_config if orig_config.get(k) is None]
-    juju.config(app_name, restore_config, reset=reset_config)
+    juju.config(app_name, restore_config, reset=reset_config, log=False)
 
     for secret_id in secret_ids:
         juju.remove_secret(secret_id)

--- a/tests/integration/flask/test_charm.py
+++ b/tests/integration/flask/test_charm.py
@@ -206,7 +206,9 @@ def test_port_without_ingress(
     service_hostname = f"{flask_app.name}.{model_name}"
     unit_name = list(status.apps[flask_app.name].units.keys())[0]
 
-    task = juju.exec(command=f"/usr/bin/getent hosts {service_hostname}", unit=unit_name)
+    task = juju.exec(
+        command=f"/usr/bin/getent hosts {service_hostname}", unit=unit_name, log=False
+    )
     assert task.return_code == 0
     service_ip = task.stdout.split()[0]
 

--- a/tests/integration/flask/test_database.py
+++ b/tests/integration/flask/test_database.py
@@ -42,7 +42,7 @@ def test_with_database(
     """
     # Deploy database if not already deployed
     if not juju.status().apps.get(db_name):
-        juju.deploy(db_name, channel=db_channel, revision=revision, trust=trust)
+        juju.deploy(db_name, channel=db_channel, revision=revision, trust=trust, log=False)
 
     juju.wait(lambda status: status.apps.get(db_name, False) and status.apps[db_name].is_active)
 

--- a/tests/integration/flask/test_proxy.py
+++ b/tests/integration/flask/test_proxy.py
@@ -57,7 +57,7 @@ def test_proxy(
 
     # Deploy the charm
     try:
-        juju.deploy(charm=charm_file, app=app_name, resources=resources)
+        juju.deploy(charm=charm_file, app=app_name, resources=resources, log=False)
     except jubilant.CLIError as err:
         if "application already exists" not in err.stderr:
             raise err

--- a/tests/integration/flask/test_workers.py
+++ b/tests/integration/flask/test_workers.py
@@ -22,7 +22,7 @@ def redis_k8s_app_fixture(juju: jubilant.Juju):
     """Deploy Redis k8s charm."""
     redis_app_name = "redis-k8s"
     if not juju.status().apps.get(redis_app_name):
-        juju.deploy(redis_app_name, channel="edge")
+        juju.deploy(redis_app_name, channel="edge", log=False)
     juju.wait(lambda status: status.apps[redis_app_name].is_active)
     return App(redis_app_name)
 
@@ -118,7 +118,7 @@ def test_async_workers(
     act: Do 15 requests that would take 2 seconds each.
     assert: All 15 requests should be served in under 3 seconds.
     """
-    juju.config(flask_async_app.name, {"webserver-worker-class": "gevent"})
+    juju.config(flask_async_app.name, {"webserver-worker-class": "gevent"}, log=False)
     juju.wait(lambda status: status.apps[flask_async_app.name].is_active, timeout=60)
 
     # the flask unit is not important. Take the first one

--- a/tests/integration/general/test_config.py
+++ b/tests/integration/general/test_config.py
@@ -80,7 +80,7 @@ def test_non_optional(
             missing_config in app_status.app_status.message
         ), f"{missing_config} should not be set"
 
-    juju.config(blocked_app.name, first_non_optional_config)
+    juju.config(blocked_app.name, first_non_optional_config, log=False)
     juju.wait(lambda status: status.apps[blocked_app.name].is_blocked, timeout=5 * 60)
     status = juju.status()
     app_status = status.apps[blocked_app.name]
@@ -91,7 +91,7 @@ def test_non_optional(
     for config in first_non_optional_config.keys():
         assert config not in app_status.app_status.message, f"{config} should be set"
 
-    juju.config(blocked_app.name, remaining_non_optional_configs_dict)
+    juju.config(blocked_app.name, remaining_non_optional_configs_dict, log=False)
     juju.wait(lambda status: status.apps[blocked_app.name].is_active, timeout=5 * 60)
     status = juju.status()
     app_status = status.apps[blocked_app.name]

--- a/tests/integration/go/test_go.py
+++ b/tests/integration/go/test_go.py
@@ -36,7 +36,7 @@ def test_user_defined_config(
     act: call the endpoint to get the value of the env variable related to the config.
     assert: the value of the env variable and the config should match.
     """
-    juju.config(go_app.name, {"user-defined-config": "newvalue"})
+    juju.config(go_app.name, {"user-defined-config": "newvalue"}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, go_app.name, "postgresql-k8s"))
 
     status = juju.status()
@@ -100,7 +100,7 @@ def test_open_ports(
 
     # Change port configuration
     new_port = WORKLOAD_PORT + 10
-    juju.config(go_app.name, {"app-port": str(new_port)})
+    juju.config(go_app.name, {"app-port": str(new_port)}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, go_app.name, traefik_app.name))
 
     opened_ports = juju.cli("exec", "--unit", f"{go_app.name}/0", "opened-ports")
@@ -115,7 +115,7 @@ def test_open_ports(
     )
 
     # Restore original port
-    juju.config(go_app.name, {"app-port": str(WORKLOAD_PORT)})
+    juju.config(go_app.name, {"app-port": str(WORKLOAD_PORT)}, log=False)
     juju.wait(lambda status: jubilant.all_active(status, go_app.name, traefik_app.name))
 
     opened_ports = juju.cli("exec", "--unit", f"{go_app.name}/0", "opened-ports")

--- a/tests/integration/integrations/conftest.py
+++ b/tests/integration/integrations/conftest.py
@@ -110,12 +110,7 @@ def s3_configuration_fixture(minio_app_name: str) -> dict:
 def minio_app_fixture(juju: jubilant.Juju, minio_app_name, s3_credentials):
     """Deploy and set up minio and s3-integrator needed for s3-like storage backend in the HA charms."""
     config = s3_credentials
-    juju.deploy(
-        minio_app_name,
-        channel="edge",
-        config=config,
-        trust=True,
-    )
+    juju.deploy(minio_app_name, channel="edge", config=config, trust=True, log=False)
 
     juju.wait(lambda status: status.apps[minio_app_name].is_active, timeout=60 * 30)
     return App(minio_app_name)
@@ -129,11 +124,7 @@ def redis_app_name_fixture() -> str:
 @pytest.fixture(scope="module", name="redis_app")
 def redis_app_fixture(juju: jubilant.Juju, redis_app_name):
     """Deploy and set up Redis."""
-    juju.deploy(
-        redis_app_name,
-        channel="latest/edge",
-        trust=True,
-    )
+    juju.deploy(redis_app_name, channel="latest/edge", trust=True, log=False)
 
     return App(redis_app_name)
 
@@ -146,12 +137,7 @@ def mongodb_app_name_fixture() -> str:
 @pytest.fixture(scope="module", name="mongodb_app")
 def mongodb_app_fixture(juju: jubilant.Juju, mongodb_app_name):
     """Deploy and set up Redis."""
-    juju.deploy(
-        mongodb_app_name,
-        channel="6/beta",
-        revision=61,
-        trust=True,
-    )
+    juju.deploy(mongodb_app_name, channel="6/beta", revision=61, trust=True, log=False)
 
     return App(mongodb_app_name)
 
@@ -165,12 +151,7 @@ def mysql_app_name_fixture() -> str:
 def mysql_app_fixture(juju: jubilant.Juju, mysql_app_name):
     """Deploy and set up Redis."""
     if not juju.status().apps.get(mysql_app_name):
-        juju.deploy(
-            mysql_app_name,
-            channel="8.0/stable",
-            revision=140,
-            trust=True,
-        )
+        juju.deploy(mysql_app_name, channel="8.0/stable", revision=140, trust=True, log=False)
 
     return App(mysql_app_name)
 
@@ -178,10 +159,7 @@ def mysql_app_fixture(juju: jubilant.Juju, mysql_app_name):
 @pytest.fixture(scope="module", name="s3_integrator_app")
 def s3_integrator_app_fixture(juju: jubilant.Juju, minio_app, s3_credentials, s3_configuration):
     s3_integrator = "s3-integrator"
-    juju.deploy(
-        s3_integrator,
-        channel="edge",
-    )
+    juju.deploy(s3_integrator, channel="edge", log=False)
     juju.wait(
         lambda status: jubilant.all_blocked(status, s3_integrator),
         timeout=120,
@@ -203,10 +181,7 @@ def s3_integrator_app_fixture(juju: jubilant.Juju, minio_app, s3_credentials, s3
         mc_client.make_bucket(bucket_name)
 
     # configure s3-integrator
-    juju.config(
-        "s3-integrator",
-        s3_configuration,
-    )
+    juju.config("s3-integrator", s3_configuration, log=False)
 
     task = juju.run(f"{s3_integrator}/0", "sync-s3-credentials", s3_credentials)
     assert task.status == "completed"
@@ -224,16 +199,14 @@ def tempo_app_fixture(
     tempo_worker_charm_url, worker_channel = "tempo-worker-k8s", "2/edge"
     tempo_coordinator_charm_url, coordinator_channel = "tempo-coordinator-k8s", "2/edge"
     juju.deploy(
-        tempo_worker_charm_url,
-        app=worker_app,
-        channel=worker_channel,
-        trust=True,
+        tempo_worker_charm_url, app=worker_app, channel=worker_channel, trust=True, log=False
     )
     juju.deploy(
         tempo_coordinator_charm_url,
         app=tempo_app,
         channel=coordinator_channel,
         trust=True,
+        log=False,
     )
     juju.integrate(f"{tempo_app}:s3", f"{s3_integrator_app.name}:s3-credentials")
     juju.integrate(f"{tempo_app}:tempo-cluster", f"{worker_app}:tempo-cluster")
@@ -337,6 +310,7 @@ def deploy_prometheus_fixture(
             revision=129,
             base="ubuntu@20.04",
             trust=True,
+            log=False,
         )
     juju.wait(
         lambda status: status.apps[prometheus_app_name].is_active,
@@ -353,7 +327,7 @@ def deploy_loki_fixture(
 ) -> App:
     """Deploy loki."""
     if not juju.status().apps.get(loki_app_name):
-        juju.deploy(loki_app_name, channel="1/stable", trust=True)
+        juju.deploy(loki_app_name, channel="1/stable", trust=True, log=False)
     juju.wait(
         lambda status: status.apps[loki_app_name].is_active,
         error=jubilant.any_blocked,
@@ -376,6 +350,7 @@ def deploy_cos_fixture(
             revision=82,
             base="ubuntu@20.04",
             trust=True,
+            log=False,
         )
         juju.wait(
             lambda status: jubilant.all_active(
@@ -406,7 +381,7 @@ def deploy_openfga_server_fixture(juju: jubilant.Juju) -> App:
         return openfga_server_app
 
     deploy_postgresql(juju)
-    juju.deploy(openfga_server_app.name, channel="latest/stable")
+    juju.deploy(openfga_server_app.name, channel="latest/stable", log=False)
     juju.integrate(openfga_server_app.name, "postgresql-k8s:database")
     juju.wait(
         lambda status: jubilant.all_active(status, openfga_server_app.name, "postgresql-k8s"),
@@ -478,10 +453,7 @@ def deploy_rabbitmq_server_fixture(juju: jubilant.Juju, lxd_controller, lxd_mode
             logger.info("rabbitmq server already deployed")
             return App(rabbitmq_server_name)
 
-        juju.deploy(
-            rabbitmq_server_name,
-            channel="edge",
-        )
+        juju.deploy(rabbitmq_server_name, channel="edge", log=False)
 
         juju.cli("offer", f"{rabbitmq_server_name}:amqp", include_model=False)
         juju.wait(
@@ -522,11 +494,7 @@ def deploy_rabbitmq_k8s_fixture(juju: jubilant.Juju) -> App:
         logger.info(f"{rabbitmq_k8s.name} is already deployed")
         return rabbitmq_k8s
 
-    juju.deploy(
-        rabbitmq_k8s.name,
-        channel="3.12/edge",
-        trust=True,
-    )
+    juju.deploy(rabbitmq_k8s.name, channel="3.12/edge", trust=True, log=False)
     juju.wait(
         lambda status: jubilant.all_active(status, rabbitmq_k8s.name),
         timeout=10 * 60,
@@ -540,14 +508,29 @@ def deploy_identity_bundle_fixture(juju: jubilant.Juju):
     if juju.status().apps.get("hydra"):
         logger.info("identity-platform is already deployed")
         return
-    juju.deploy("hydra", channel="latest/edge", revision=399, trust=True)
-    juju.deploy("kratos", channel="latest/edge", revision=567, trust=True)
+    juju.deploy("hydra", channel="latest/edge", revision=399, trust=True, log=False)
+    juju.deploy("kratos", channel="latest/edge", revision=567, trust=True, log=False)
     juju.deploy(
-        "identity-platform-login-ui-operator", channel="latest/edge", revision=200, trust=True
+        "identity-platform-login-ui-operator",
+        channel="latest/edge",
+        revision=200,
+        trust=True,
+        log=False,
     )
-    juju.deploy("self-signed-certificates", channel="1/stable", revision=317, trust=True)
-    juju.deploy("traefik-k8s", "traefik-admin", channel="latest/stable", revision=176, trust=True)
-    juju.deploy("traefik-k8s", "traefik-public", channel="latest/edge", revision=270, trust=True)
+    juju.deploy(
+        "self-signed-certificates", channel="1/stable", revision=317, trust=True, log=False
+    )
+    juju.deploy(
+        "traefik-k8s",
+        "traefik-admin",
+        channel="latest/stable",
+        revision=176,
+        trust=True,
+        log=False,
+    )
+    juju.deploy(
+        "traefik-k8s", "traefik-public", channel="latest/edge", revision=270, trust=True, log=False
+    )
     deploy_postgresql(juju)
     # Integrations
     juju.integrate(
@@ -571,7 +554,7 @@ def deploy_identity_bundle_fixture(juju: jubilant.Juju):
         "traefik-public:traefik-route", "identity-platform-login-ui-operator:public-route"
     )
 
-    juju.config("kratos", {"enforce_mfa": False})
+    juju.config("kratos", {"enforce_mfa": False}, log=False)
 
 
 @pytest.fixture(scope="module", name="http_proxy_app")
@@ -584,9 +567,7 @@ def http_proxy_configurator_fixture(juju: jubilant.Juju, lxd_controller, lxd_mod
             logger.info("squid server already deployed")
         else:
             juju.deploy(
-                squid_proxy,
-                channel="edge",
-                config={"hostname": "proxy.example.com"},
+                squid_proxy, channel="edge", config={"hostname": "proxy.example.com"}, log=False
             )
 
             juju.cli("offer", f"{squid_proxy}:http-proxy", include_model=False)
@@ -610,6 +591,7 @@ def http_proxy_configurator_fixture(juju: jubilant.Juju, lxd_controller, lxd_mod
                 "http-proxy-auth": "none",
                 "http-proxy-domains": "www.example.com",
             },
+            log=False,
         )
         juju.integrate(http_proxy_configurator, squid_proxy)
     juju.wait(

--- a/tests/integration/integrations/test_saml.py
+++ b/tests/integration/integrations/test_saml.py
@@ -46,10 +46,7 @@ def test_saml_integration(
 
     saml_integrator_app_name = "saml-integrator"
     juju.deploy(
-        saml_integrator_app_name,
-        channel="latest/edge",
-        base="ubuntu@22.04",
-        trust=True,
+        saml_integrator_app_name, channel="latest/edge", base="ubuntu@22.04", trust=True, log=False
     )
 
     juju.wait(lambda status: jubilant.all_blocked(status, saml_integrator_app_name), timeout=600)
@@ -63,6 +60,7 @@ def test_saml_integration(
             "entity_id": saml_helper.entity_id,
             "metadata_url": saml_helper.metadata_url,
         },
+        log=False,
     )
 
     juju.integrate(saml_integrator_app_name, app.name)

--- a/tests/integration/integrations/test_smtp.py
+++ b/tests/integration/integrations/test_smtp.py
@@ -49,7 +49,7 @@ def test_smtp_integrations(
     }
     smtp_integrator_app = "smtp-integrator"
     if not juju.status().apps.get(smtp_integrator_app):
-        juju.deploy(smtp_integrator_app, channel="latest/edge", config=smtp_config)
+        juju.deploy(smtp_integrator_app, channel="latest/edge", config=smtp_config, log=False)
 
     juju.wait(lambda status: jubilant.all_active(status, app.name, smtp_integrator_app))
 

--- a/tests/integration/springboot/conftest.py
+++ b/tests/integration/springboot/conftest.py
@@ -113,5 +113,7 @@ def saml_integrator_fixture(juju: jubilant.Juju, simplesamlphp_ip: str):
         "entity_id": f"http://{simplesamlphp_ip}:8080/simplesaml/saml2/idp/metadata.php",
         "metadata_url": f"http://{simplesamlphp_ip}:8080/simplesaml/saml2/idp/metadata.php",
     }
-    juju.deploy("saml-integrator", channel="latest/stable", config=saml_config, trust=True)
+    juju.deploy(
+        "saml-integrator", channel="latest/stable", config=saml_config, trust=True, log=False
+    )
     yield App("saml-integrator")


### PR DESCRIPTION
## Summary

Disable jubilant logging for all `juju.deploy()`, `juju.config()` and `juju.exec()` calls in integration tests by adding `log=False`.