### PR TITLE
fix: prevent duplicate allowed_hosts when ingress hostname matches config

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Place any unreleased changes here, that are subject to release in coming versions :).
+* fix: Prevent duplicate allowed_hosts when ingress hostname matches charm config.
+  This avoids duplicating hostnames that were already configured by the user
+  via the `django-allowed-hosts` charm config option.
 
 ## 1.11.2 - 2026-04-30
 

--- a/src/paas_charm/django/charm.py
+++ b/src/paas_charm/django/charm.py
@@ -80,7 +80,8 @@ class Charm(GunicornBase):
         base_model = super().get_framework_config()
         url = urlsplit(self._base_url)
         # base_model can be downcasted to a DjangoConfig, and allowed_hosts is really a list.
-        base_model.allowed_hosts.append(url.hostname)  # type: ignore
+        if url.hostname not in base_model.allowed_hosts:  # type: ignore
+            base_model.allowed_hosts.append(url.hostname)  # type: ignore
         return base_model
 
     def is_ready(self) -> bool:

--- a/tests/unit/django/test_charm.py
+++ b/tests/unit/django/test_charm.py
@@ -232,6 +232,43 @@ def test_django_async_config(harness: Harness, config: dict, env: dict) -> None:
     }
 
 
+def test_allowed_hosts_deduplicates_when_configured_host_matches_ingress(
+    harness: Harness,
+):
+    """
+    arrange: Configure the django charm with an allowed host that matches the ingress url hostname.
+    act: Start the django charm and add an ingress relation.
+    assert: The allowed hosts should not contain duplicates.
+    """
+    postgresql_relation_data = {
+        "database": "test-database",
+        "endpoints": "test-postgresql:5432,test-postgresql-2:5432",
+        "password": "test-password",
+        "username": "test-username",
+    }
+    harness.add_relation("postgresql", "postgresql-k8s", app_data=postgresql_relation_data)
+    container = harness.model.unit.get_container(DJANGO_CONTAINER_NAME)
+    container.add_layer("a_layer", DEFAULT_LAYER)
+    harness.set_model_name("test-model")
+    harness.update_config({"django-allowed-hosts": "django-k8s.test-model"})
+    harness.begin_with_initial_hooks()
+
+    plan = container.get_plan()
+    env = plan.to_dict()["services"]["django"]["environment"]
+    assert env["DJANGO_ALLOWED_HOSTS"] == '["django-k8s.test-model"]'
+
+    harness.add_network("10.0.0.10", endpoint="ingress")
+    harness.add_relation(
+        "ingress",
+        "nginx-ingress-integrator",
+        app_data={"ingress": '{"url": "https://django-k8s.test-model/"}'},
+    )
+
+    plan = container.get_plan()
+    env = plan.to_dict()["services"]["django"]["environment"]
+    assert env["DJANGO_ALLOWED_HOSTS"] == '["django-k8s.test-model"]'
+
+
 def test_allowed_hosts_base_hostname_updates_correctly(harness: Harness):
     """
     arrange: Deploy a Django charm without an ingress integration


### PR DESCRIPTION
#### What this PR does

Add a membership check before appending the ingress URL's hostname to allowed_hosts in get_framework_config()

#### Why we need it

The get_framework_config() unconditionally appends the ingress URL's hostname to allowed_hosts, which duplicates it when the user has already configured the same hostname via the django-allowed-hosts charm config. 

Related: canonical/netbox-k8s-operator#86

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

