### PR TITLE
fix: Include 404 to retry list

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   integration-tests:
+    permissions:
+      packages: write
+      pull-requests: write
     strategy:
       matrix:
         juju-version: [3.6/stable]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -38,7 +38,7 @@ def fixture_session_with_retry():
         read=5,
         other=5,
         backoff_factor=5,
-        status_forcelist=[429, 500, 502, 503, 504],
+        status_forcelist=[404, 429, 500, 502, 503, 504],
         allowed_methods=["HEAD", "POST", "GET", "OPTIONS"],
         raise_on_status=False,
     )


### PR DESCRIPTION
#### What this PR does

Adds 404 status to retry statuses.

#### Why we need it

Especially the Go port test sometimes gets flaky and the request needs to be retried. The fail status is 404 in this test but the retry logic did not include 404 status.

#### Checklist

- [ ] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

