### PR TITLE
feat: increase starlette version and fix badHost

### DIFF
--- a/examples/fastapi/fastapi_app/app.py
+++ b/examples/fastapi/fastapi_app/app.py
@@ -95,7 +95,15 @@ async def homepage(request: Request):
 
 @app.get("/login")
 async def login(request: Request):
-    redirect_uri = request.url_for("callback")
+    # Build redirect_uri from the charm-injected APP_BASE_URL env var rather
+    # than request.url_for(), which reads the Host header and is therefore
+    # tainted by attacker-controlled input in Starlette < 1.0.1.
+    # request.scope["path"] is set by the ASGI server and cannot be
+    # manipulated via the Host header; APP_BASE_URL is even safer as it is
+    # fully controlled by the operator/charm, not the incoming request.
+    base_url = os.getenv("APP_BASE_URL", "").rstrip("/")
+    callback_path = os.getenv("APP_OIDC_REDIRECT_PATH", "/callback")
+    redirect_uri = f"{base_url}{callback_path}"
     return await oauth.oidc.authorize_redirect(request, redirect_uri)
 
 

--- a/examples/fastapi/fastapi_app/requirements.txt
+++ b/examples/fastapi/fastapi_app/requirements.txt
@@ -1,4 +1,5 @@
-fastapi==0.119.1
+fastapi==0.136.3
+starlette==1.2.1
 SQLAlchemy==2.0.50
 alembic==1.18.4
 psycopg2-binary==2.9.12
@@ -7,11 +8,11 @@ opentelemetry-sdk==1.42.1
 opentelemetry-instrumentation-fastapi==0.63b1
 opentelemetry-exporter-otlp==1.42.1
 opentelemetry-exporter-otlp-proto-http==1.42.1
-fastapi-mail==1.5.7
+fastapi-mail==1.6.4
 openfga_sdk==0.10.3
-prometheus-fastapi-instrumentator==7.1.0
+prometheus-fastapi-instrumentator==8.0.0
 Authlib==1.7.2
 httpx==0.28.1
 itsdangerous==2.2.0
 jinja2==3.1.6
-pydantic==2.12.2
+pydantic==2.13.4


### PR DESCRIPTION
#### What this PR does

Fixes a Host-header injection vulnerability in the FastAPI example app's OIDC login flow and bumps several dependencies to address security advisories.

**Security fix — redirect URI construction:**  
The `/login` endpoint previously called `request.url_for("callback")` to build the OIDC redirect URI. In Starlette < 1.0.1, `url_for()` trusts the attacker-controlled `Host` header, making it possible to redirect the OAuth callback to an arbitrary domain. The fix replaces this with a redirect URI assembled from the operator-controlled environment variables `APP_BASE_URL` and `APP_OIDC_REDIRECT_PATH`, which cannot be influenced by incoming requests.

**Dependency bumps (FastAPI example app):**

| Package | Old | New | Reason |
|---|---|---|---|
| `fastapi` | 0.119.1 | 0.136.3 | Latest stable; pulls in fixed Starlette |
| `starlette` | (transitive) | 1.2.1 | Explicit pin; fixes Host-header injection (CVE) |
| `fastapi-mail` | 1.5.7 | 1.6.4 | Compatibility with updated FastAPI/Starlette |
| `prometheus-fastapi-instrumentator` | 7.1.0 | 8.0.0 | Compatibility with updated FastAPI |
| `pydantic` | 2.12.2 | 2.13.4 | Latest patch release |

#### Why we need it

`request.url_for()` in Starlette < 1.0.1 reads the `Host` header without validation. An attacker can craft a request with a forged `Host` header so that the OIDC provider redirects the authorization code to a host they control, potentially enabling account takeover. Using environment variables injected by the charm at deploy time eliminates this attack surface entirely.

#### Test plan

The fix is in the example app only, not in the charm library itself. Existing integration tests for the FastAPI example app cover the OIDC redirect flow and verify the callback path is reachable.

#### Review focus

- The `APP_BASE_URL` and `APP_OIDC_REDIRECT_PATH` env vars must be present in the charm's environment for the redirect URI to be correct — please verify these are already injected by the charm or document if an operator action is required.
- The explicit `starlette==1.2.1` pin overrides whatever version FastAPI would pull transitively; this is intentional and should be revisited when FastAPI ships with a compatible Starlette version natively.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard