### PR TITLE
chore: disable valkey test for  now

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -50,8 +50,7 @@ jobs:
           "test_spring_saml.py",
           "test_redis.py",
           "test_mongodb.py",
-          "test_mysql.py",
-        # "test_valkey.py" disabled until [valkey issue #70](https://github.com/canonical/valkey-operator/issues/70) is resolved.
+          "test_mysql.py"
         ]
       rockcraft-channel: latest/edge
       juju-channel: ${{ matrix.juju-version }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -51,7 +51,7 @@ jobs:
           "test_redis.py",
           "test_mongodb.py",
           "test_mysql.py",
-          "test_valkey.py"
+        # "test_valkey.py" disabled until [valkey issue #70](https://github.com/canonical/valkey-operator/issues/70) is resolved.
         ]
       rockcraft-channel: latest/edge
       juju-channel: ${{ matrix.juju-version }}


### PR DESCRIPTION
#### What this PR does

disabled valkey tests until issue [#70](https://github.com/canonical/valkey-operator/issues/70) is resolved.
There is a race condition in valkey that makes it immediately go into error state when deployed. This is blocking all our pr's, so we will momentarily disable the test and re-enable them once the issue [#70](https://github.com/canonical/valkey-operator/issues/70) is resolved. 

#### Why we need it

#### Checklist

- [ ] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

