### PR TITLE
ci: temporarily use alithethird/rockcraft 1.90.1 fork for integration test rock builds

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -16,6 +16,30 @@ jobs:
     with:
       charmcraft-channel: latest/edge
       rockcraft-channel: latest/edge
+      # Sideload the alithethird/rockcraft 1.90.1 CI test fork as a parallel
+      # snap instance and shadow the official rockcraft binary with it via
+      # /usr/local/bin (which precedes /snap/bin on the runner's PATH), so
+      # the subsequent "Install rockcraft" step in the reusable workflow
+      # installs the official snap normally but rock builds still resolve
+      # to the fork's rockcraft binary.
+      # TODO: revert to the official rockcraft snap once CI testing with
+      # https://github.com/alithethird/rockcraft/releases/tag/1.90.1 is done.
+      pre-build-rock-script: |
+        set -euo pipefail
+        rockcraft_fork_url="https://github.com/alithethird/rockcraft/releases/download/1.90.1/rockcraft_1.19.0.post104%2Bg78186d4_amd64.snap"
+        rockcraft_fork_snap="$(mktemp -t rockcraft-fork-XXXXXX.snap)"
+        curl -sSfL "${rockcraft_fork_url}" -o "${rockcraft_fork_snap}"
+        sudo snap set system experimental.parallel-instances=true
+        sudo snap install --dangerous --classic --name rockcraft_fork "${rockcraft_fork_snap}"
+        rm -f "${rockcraft_fork_snap}"
+        if [ ! -x /snap/bin/rockcraft_fork ]; then
+          echo "::error::expected /snap/bin/rockcraft_fork binary was not created by the parallel snap install" >&2
+          exit 1
+        fi
+        sudo ln -sf /snap/bin/rockcraft_fork /usr/local/bin/rockcraft
+        hash -r
+        echo "rockcraft resolves to: $(command -v rockcraft)"
+        rockcraft version
   required_status_checks:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Purpose

**Temporary CI test.** This PR routes rock builds in the integration test workflow to a fork build of Rockcraft ([alithethird/rockcraft release 1.90.1](https://github.com/alithethird/rockcraft/releases/tag/1.90.1)) instead of the official snap channel, in order to validate that fork's changes against paas-charm's integration test suite.

**This should not be merged as-is** — it's meant to run CI against the fork build and be reverted (or closed) once that testing is complete.

## How it works

The `canonical/charm-ci` reusable integration-test workflow only supports installing Rockcraft from a snap-store channel (`rockcraft-channel` input → `snap install rockcraft --channel=...`). The fork build isn't published to the snap store — it's a raw `.snap` asset attached to a GitHub Release, meant to be sideloaded.

To work around this without modifying `charm-ci` itself, this PR adds a `pre-build-rock-script` (an existing extension point that charm-ci runs before its own rockcraft install step, for rock builds only) that:

1. Downloads the pinned, exact asset URL for the fork build (`rockcraft_1.19.0.post104+g78186d4_amd64.snap`) — not a dynamically-selected artifact.
2. Enables `experimental.parallel-instances` and sideloads it as a parallel snap instance named `rockcraft_fork` (`snap install --dangerous --classic --name rockcraft_fork ...`), so it doesn't collide with charm-ci's own subsequent `snap install rockcraft --channel=...` step.
3. Fails fast (`set -euo pipefail`, explicit check that `/snap/bin/rockcraft_fork` exists) if the sideload doesn't succeed as expected.
4. Symlinks `/usr/local/bin/rockcraft` → `/snap/bin/rockcraft_fork`. Since `/usr/local/bin` precedes `/snap/bin` on the GitHub Actions runner `PATH`, this shadows the official rockcraft binary that charm-ci installs afterward, so rock builds resolve to the fork build.
5. Prints `command -v rockcraft` and `rockcraft version` in the CI log as evidence of which build is actually active during the run.

## Validation

- `actionlint` on the modified workflow and all other workflow files: clean, no findings.
- Workflow YAML parses correctly and the embedded script extracts as expected.
- Extracted shell script: passes `bash -n` syntax check and `shellcheck` with zero warnings.

## Revert plan

Once CI testing against the fork is complete, revert this change (or close this PR) to restore the official `rockcraft-channel: latest/edge` snap-channel install with no `pre-build-rock-script` override.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>