### PR TITLE
chore: add sitemap configuration

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       packages: write
       actions: read
-    uses: canonical/charm-ci/.github/workflows/integration-test.yml@main
+    uses: canonical/charm-ci/.github/workflows/integration-test.yml@v0.0.1-alpha.10
   required_status_checks:
     name: Required Integration Test Status Checks
     runs-on: ubuntu-latest

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,6 +187,8 @@ html_baseurl = f"https://canonical.com/juju/docs/12-factor/{version}/"
 
 sitemap_url_scheme = '{link}'
 
+sitemap_filename = "doc-sitemap.xml"
+
 # Include `lastmod` dates in the sitemap:
 
 sitemap_show_lastmod = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ Repository = "https://github.com/canonical/paas-charm"
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 
+[tool.uv.sources]
+# opcli is published only from the charm-ci git repository, not PyPI.
+opcli = { git = "https://github.com/canonical/charm-ci.git", tag = "v0.0.1-alpha.10" }
+
 [tool.setuptools.package-data]
 paas_charm = ["**/cos/**", "**/cos/**/.**", "**/*.j2", "**/templates/**/*.py", "**/templates/**/*.json"]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,6 +10,7 @@ import jubilant
 import pytest
 import requests
 import yaml
+from opcli.pytest_plugin import artifacts_root_from_yaml_path, build_rock_images
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -49,70 +50,35 @@ def fixture_session_with_retry():
 
 
 @pytest.fixture(scope="session", name="rock_images")
-def fixture_rock_images() -> dict[str, str]:
+def fixture_rock_images(opcli_artifacts, opcli_build_yaml_path: pathlib.Path) -> dict[str, str]:
     """Return dict of built rock images from opcli artifacts.build.yaml.
 
     Maps rock names (e.g., "test-flask", "django-app") to OCI image URLs or
-    local .rock file paths. Requires artifacts.build.yaml to exist; run
-    'opcli artifacts build' to generate it before running integration tests.
+    local .rock file paths, filtered to the current machine's architecture.
+
+    Delegates to opcli's own ``build_rock_images`` helper (see
+    ``opcli.pytest_plugin``) so discovery of artifacts.build.yaml (CLI
+    override, OPCLI_ARTIFACTS_BUILD_YAML env var, or walk-up to the repo's
+    build/ directory) and arch selection stay in sync with opcli itself,
+    instead of being reimplemented here.
     """
-    artifacts_build = PROJECT_ROOT / "artifacts.build.yaml"
-    if not artifacts_build.exists():
-        pytest.fail(
-            f"{artifacts_build} not found. Run 'opcli artifacts build' to generate "
-            "build artifacts before running integration tests."
-        )
-    data = yaml.safe_load(artifacts_build.read_text())
-    # artifacts.build.yaml uses a list of GeneratedRock objects:
-    # rocks:
-    #   - name: test-flask
-    #     builds:
-    #       - arch: amd64
-    #         image: ghcr.io/...   (registry build)
-    #         # or file: ./path/to.rock  (local build)
-    result = {}
-    for rock in data.get("rocks", []):
-        name = rock["name"]
-        for build in rock.get("builds", []):
-            ref = build.get("image") or build.get("file") or ""
-            if ref:
-                result[name] = ref
-                break
-    return result
+    return build_rock_images(opcli_artifacts, artifacts_root_from_yaml_path(opcli_build_yaml_path))
 
 
 @pytest.fixture(scope="session", name="charm_paths")
-def fixture_charm_paths() -> dict[str, pathlib.Path]:
+def fixture_charm_paths(charm_paths) -> dict[str, pathlib.Path]:
     """Return dict of pre-built charm paths from opcli artifacts.build.yaml.
 
     Maps charm names (e.g., "flask-k8s", "django-k8s") to local .charm file
-    paths. Requires artifacts.build.yaml to exist; run 'opcli artifacts build'
-    to generate it before running integration tests.
+    paths.
+
+    This overrides opcli's own ``charm_paths`` fixture (requested here by the
+    same name, per pytest's fixture-override mechanism) to adapt its
+    multi-base ``CharmPathList`` values down to a single ``pathlib.Path`` per
+    charm, which is the shape this test suite's fixtures/tests expect. All
+    artifacts.build.yaml discovery and arch selection is delegated to opcli.
     """
-    artifacts_build = PROJECT_ROOT / "artifacts.build.yaml"
-    if not artifacts_build.exists():
-        pytest.fail(
-            f"{artifacts_build} not found. Run 'opcli artifacts build' to generate "
-            "build artifacts before running integration tests."
-        )
-    data = yaml.safe_load(artifacts_build.read_text())
-    # artifacts.build.yaml uses a list of GeneratedCharm objects:
-    # charms:
-    #   - name: flask-k8s
-    #     builds:
-    #       - arch: amd64
-    #         path: ./flask-k8s_ubuntu@26.04-amd64.charm
-    result = {}
-    for charm in data.get("charms", []):
-        name = charm["name"]
-        for build in charm.get("builds", []):
-            path = build.get("path")
-            if path:
-                # Resolve relative to PROJECT_ROOT so shutil.copy2 can
-                # find the file regardless of the pytest working directory.
-                result[name] = (PROJECT_ROOT / path).resolve()
-                break
-    return result
+    return {name: pathlib.Path(paths.path) for name, paths in charm_paths.items()}
 
 
 @pytest.fixture(scope="module", name="test_flask_image")

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -8,5 +8,5 @@ minio==7.2.14
 ops==3.8.0
 tenacity==9.0.0
 playwright==1.61.0
-opcli @ git+https://github.com/canonical/charm-ci.git@b4788978c987440a24360f3fb7cb879961ddb4c5
+opcli @ git+https://github.com/canonical/charm-ci.git@v0.0.1-alpha.10
 pytest==9.1.1


### PR DESCRIPTION
#### What this PR does

Adds `sitemap_filename` to `docs/conf.py` for the v1 version.

#### Why we need it

Aligns with recommended sitemap configuration according to https://documentation.ubuntu.com/rtd-proxy/how-to/migrate/#sitemaps

The current canonical.com sitemap is throwing a 404 for this version of the 12-factor docs

#### Validation

https://canonical-12-factor--336.com.readthedocs.build/336/doc-sitemap.xml

(Uses `doc-sitemap.xml` instead of `sitemap.xml`)

#### Checklist

- [X] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [X] I added or updated the documentation (if applicable)
- [N/A] I updated `docs/changelog.md` with user-relevant changes
- [N/A] I used AI to assist with preparing this PR
- [N/A] I added or updated tests as needed (unit and integration)
- [N/A] **If I added or changed integration tests:** I updated the charm-ci configuration  
      as needed (`spread.yaml` `integration-suites` and/or `artifacts.yaml`)
- [N/A] **If this is a Grafana dashboard:** I added a screenshot of the dashboard

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

