### PR TITLE
test: root Spring Boot Scenario context

### DIFF
--- a/tests/unit/springboot/conftest.py
+++ b/tests/unit/springboot/conftest.py
@@ -3,26 +3,41 @@
 
 """pytest fixtures for the Springboot unit test."""
 
-import os
 import pathlib
+import typing
+from unittest import mock
 
 import pytest
 from ops import testing
 
+from examples.springboot.charm.src.charm import SpringBootCharm
+from paas_charm.paas_config import read_paas_config
 from tests.unit.conftest import postgresql_relation
 
+from .constants import DEFAULT_LAYER
+
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
+SPRINGBOOT_CHARM_ROOT = PROJECT_ROOT / "examples/springboot/charm"
 
 
-@pytest.fixture(autouse=True, scope="package")
-def cwd():
-    return os.chdir(PROJECT_ROOT / "examples/springboot/charm")
+@pytest.fixture(name="springboot_context")
+def springboot_context_fixture() -> typing.Generator[testing.Context[SpringBootCharm], None, None]:
+    """Context rooted at the Spring Boot example charm."""
+    with (
+        mock.patch(
+            "paas_charm.charm.read_paas_config",
+            return_value=read_paas_config(SPRINGBOOT_CHARM_ROOT),
+        ),
+        testing.Context(SpringBootCharm, charm_root=SPRINGBOOT_CHARM_ROOT) as context,
+    ):
+        yield context
 
 
-@pytest.fixture(scope="function", name="base_state")
+@pytest.fixture(name="base_state")
 def base_state_fixture():
     """State with container and config file set."""
-    yield {
+    return {
+        "leader": True,
         "relations": [
             testing.PeerRelation(
                 "secret-storage", local_app_data={"spring-boot_secret_key": "test"}
@@ -34,15 +49,7 @@ def base_state_fixture():
                 name="app",
                 can_connect=True,
                 mounts={"data": testing.Mount(location="/app/saml.cert", source="cert")},
-                _base_plan={
-                    "services": {
-                        "spring-boot": {
-                            "startup": "enabled",
-                            "override": "replace",
-                            "command": 'bash -c "java -jar *.jar"',
-                        }
-                    }
-                },
+                _base_plan=DEFAULT_LAYER,
             )
         },
         "model": testing.Model(name="test-model"),
@@ -58,17 +65,18 @@ def mysql_relation_fixture():
         "password": "test-password",
         "username": "test-username",
     }
-    yield testing.Relation(
+    return testing.Relation(
         endpoint="mysql",
         interface="mysql_client",
         remote_app_data=relation_data,
     )
 
 
-@pytest.fixture(scope="function", name="mysql_base_state")
+@pytest.fixture(name="mysql_base_state")
 def base_state_fixture_with_mysql(mysql_relation):
     """State with container and config file set."""
-    yield {
+    return {
+        "leader": True,
         "relations": [
             testing.PeerRelation(
                 "secret-storage", local_app_data={"spring-boot_secret_key": "test"}
@@ -80,15 +88,7 @@ def base_state_fixture_with_mysql(mysql_relation):
                 name="app",
                 can_connect=True,
                 mounts={"data": testing.Mount(location="/app/saml.cert", source="cert")},
-                _base_plan={
-                    "services": {
-                        "spring-boot": {
-                            "startup": "enabled",
-                            "override": "replace",
-                            "command": 'bash -c "java -jar *.jar"',
-                        }
-                    }
-                },
+                _base_plan=DEFAULT_LAYER,
             )
         },
         "model": testing.Model(name="test-model"),

--- a/tests/unit/springboot/test_charm.py
+++ b/tests/unit/springboot/test_charm.py
@@ -6,11 +6,10 @@
 # Very similar cases to other frameworks. Disable duplicated checks.
 # pylint: disable=R0801
 
+import json
 
 import pytest
 from ops import testing
-
-from examples.springboot.charm.src.charm import SpringBootCharm
 
 
 @pytest.mark.parametrize(
@@ -94,7 +93,7 @@ from examples.springboot.charm.src.charm import SpringBootCharm
         ),
     ],
 )
-def test_springboot_config(base_state, config: dict, env: dict) -> None:
+def test_springboot_config(springboot_context, base_state, config: dict, env: dict) -> None:
     """
     arrange: set the springboot charm config.
     act: start the springboot charm and set springboot-app container to be ready.
@@ -102,14 +101,11 @@ def test_springboot_config(base_state, config: dict, env: dict) -> None:
     """
     base_state["config"] = config
     state = testing.State(**base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
-    out = context.run(context.on.config_changed(), state)
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
 
     assert out.unit_status == testing.ActiveStatus()
 
-    springboot_layer = list(out.containers)[0].plan.services["spring-boot"].to_dict()
+    springboot_layer = out.get_container("app").plan.services["spring-boot"].to_dict()
     assert springboot_layer == {
         "environment": env,
         "startup": "enabled",
@@ -119,25 +115,23 @@ def test_springboot_config(base_state, config: dict, env: dict) -> None:
 
 
 def test_metrics_config(
+    springboot_context,
     base_state,
 ) -> None:
     """
-    arrange: add prometheus-k8s relation to the base state.
+    arrange: add a Prometheus scrape relation to the base state.
     act: start the springboot charm and set springboot-app container to be ready.
-    assert: prometheus-k8s relation should have the springboot charm unit name.
+    assert: relation data should contain the Spring Boot unit and workload scrape endpoint.
     """
     base_state["relations"].append(
         testing.Relation(
             endpoint="metrics-endpoint",
-            interface="prometheus-k8s",
+            interface="prometheus_scrape",
         )
     )
     state = testing.State(**base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
 
-    out = context.run(context.on.config_changed(), state)
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
 
     assert out.unit_status == testing.ActiveStatus()
 
@@ -147,3 +141,9 @@ def test_metrics_config(
     relation_data_unit = metrics_endpoint_relation[0].local_unit_data
     assert relation_data_unit["prometheus_scrape_unit_address"]
     assert relation_data_unit["prometheus_scrape_unit_name"] == "spring-boot-k8s/0"
+    assert json.loads(metrics_endpoint_relation[0].local_app_data["scrape_jobs"]) == [
+        {
+            "metrics_path": "/actuator/prometheus",
+            "static_configs": [{"targets": ["*:8080"]}],
+        }
+    ]

--- a/tests/unit/springboot/test_integrations.py
+++ b/tests/unit/springboot/test_integrations.py
@@ -8,10 +8,9 @@
 
 from ops import testing
 
-from examples.springboot.charm.src.charm import SpringBootCharm
-
 
 def test_smtp_integration(
+    springboot_context,
     base_state,
 ) -> None:
     """
@@ -34,12 +33,9 @@ def test_smtp_integration(
         )
     )
     state = testing.State(**base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
 
-    out = context.run(context.on.config_changed(), state)
-    environment = list(out.containers)[0].plan.services["spring-boot"].environment
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
+    environment = out.get_container("app").plan.services["spring-boot"].environment
     assert out.unit_status == testing.ActiveStatus()
 
     smtp_relation = out.get_relations("smtp")
@@ -54,6 +50,7 @@ def test_smtp_integration(
 
 
 def test_saml_integration(
+    springboot_context,
     base_state,
 ) -> None:
     """
@@ -75,11 +72,8 @@ def test_saml_integration(
         )
     )
     state = testing.State(**base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
-    out = context.run(context.on.config_changed(), state)
-    environment = list(out.containers)[0].plan.services["spring-boot"].environment
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
+    environment = out.get_container("app").plan.services["spring-boot"].environment
     assert out.unit_status == testing.ActiveStatus()
 
     saml_relation = out.get_relations("saml")
@@ -110,6 +104,7 @@ def test_saml_integration(
 
 
 def test_redis_integration(
+    springboot_context,
     base_state,
 ) -> None:
     """
@@ -134,12 +129,9 @@ def test_redis_integration(
         )
     )
     state = testing.State(**base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
 
-    out = context.run(context.on.config_changed(), state)
-    environment = list(out.containers)[0].plan.services["spring-boot"].environment
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
+    environment = out.get_container("app").plan.services["spring-boot"].environment
     assert out.unit_status == testing.ActiveStatus()
 
     redis_relation = out.get_relations("redis")
@@ -159,6 +151,7 @@ def test_redis_integration(
 
 
 def test_s3_integration(
+    springboot_context,
     base_state,
 ) -> None:
     """
@@ -177,12 +170,9 @@ def test_s3_integration(
         testing.Relation(endpoint="s3", interface="s3", remote_app_data=s3_app_data)
     )
     state = testing.State(**base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
 
-    out = context.run(context.on.config_changed(), state)
-    environment = list(out.containers)[0].plan.services["spring-boot"].environment
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
+    environment = out.get_container("app").plan.services["spring-boot"].environment
     assert out.unit_status == testing.ActiveStatus()
 
     s3_relation = out.get_relations("s3")
@@ -196,6 +186,7 @@ def test_s3_integration(
 
 
 def test_mongodb_integration(
+    springboot_context,
     base_state,
 ) -> None:
     """
@@ -216,12 +207,9 @@ def test_mongodb_integration(
         )
     )
     state = testing.State(**base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
 
-    out = context.run(context.on.config_changed(), state)
-    environment = list(out.containers)[0].plan.services["spring-boot"].environment
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
+    environment = out.get_container("app").plan.services["spring-boot"].environment
     assert out.unit_status == testing.ActiveStatus()
 
     mongodb_relation = out.get_relations("mongodb")
@@ -234,6 +222,7 @@ def test_mongodb_integration(
 
 
 def test_mysql_integration(
+    springboot_context,
     mysql_base_state,
 ) -> None:
     """
@@ -242,12 +231,9 @@ def test_mysql_integration(
     assert: the springboot charm should have the mysql related env variables.
     """
     state = testing.State(**mysql_base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
 
-    out = context.run(context.on.config_changed(), state)
-    environment = list(out.containers)[0].plan.services["spring-boot"].environment
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
+    environment = out.get_container("app").plan.services["spring-boot"].environment
     assert out.unit_status == testing.ActiveStatus()
 
     mysql_relation = out.get_relations("mysql")
@@ -261,6 +247,7 @@ def test_mysql_integration(
 
 
 def test_openfga_integration(
+    springboot_context,
     base_state,
 ) -> None:
     """
@@ -281,12 +268,9 @@ def test_openfga_integration(
         )
     )
     state = testing.State(**base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
 
-    out = context.run(context.on.config_changed(), state)
-    environment = list(out.containers)[0].plan.services["spring-boot"].environment
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
+    environment = out.get_container("app").plan.services["spring-boot"].environment
     assert out.unit_status == testing.ActiveStatus()
 
     openfga_relation = out.get_relations("openfga")
@@ -299,6 +283,7 @@ def test_openfga_integration(
 
 
 def test_rabbitmq_integration(
+    springboot_context,
     base_state,
 ) -> None:
     """
@@ -324,12 +309,9 @@ def test_rabbitmq_integration(
         )
     )
     state = testing.State(**base_state)
-    context = testing.Context(
-        charm_type=SpringBootCharm,
-    )
 
-    out = context.run(context.on.config_changed(), state)
-    environment = list(out.containers)[0].plan.services["spring-boot"].environment
+    out = springboot_context.run(springboot_context.on.config_changed(), state)
+    environment = out.get_container("app").plan.services["spring-boot"].environment
     assert out.unit_status == testing.ActiveStatus()
 
     rabbitmq_relation = out.get_relations("rabbitmq")


### PR DESCRIPTION
#### What this PR does

- Adds a reusable, lifecycle-managed `springboot_context` fixture rooted at the Spring Boot example charm.
- Removes the package-wide `os.chdir` fixture and repeated `Context` construction from Spring Boot tests.
- Loads the real Spring Boot `paas-config.yaml` explicitly and verifies its Prometheus scrape endpoint.
- Simplifies fixtures without teardown and preserves all integration relation assertions.

#### Why we need it

Spring Boot Scenario tests depended on the process working directory, which made them order-dependent and obscured whether the real example configuration was loaded. Rooting the Context and config lookup explicitly makes these tests deterministic and consistent with the Go test cleanup.

#### Test plan

- `pytest -q tests/unit/springboot tests/unit/general/test_paas_config.py` (82 passed)
- Spring Boot tests executed from `/tmp` (11 passed)
- Focused isort, black, codespell, and pylint checks

#### Review focus

Please verify that the rooted Context fixture and patched config reader continue to model how the packaged Spring Boot charm loads `paas-config.yaml`.

#### Potential breaking changes

None. This changes test setup only.

#### New dependencies, APIs, modules, or workflow changes

None.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [x] **If I added or changed integration tests:** I updated the charm-ci configuration  
      as needed (`spread.yaml` `integration-suites` and/or `artifacts.yaml`)
- [x] **If this is a Grafana dashboard:** I added a screenshot of the dashboard