### PR TITLE
test: migrate FastAPI unit tests to Scenario

### DIFF
--- a/tests/unit/fastapi/conftest.py
+++ b/tests/unit/fastapi/conftest.py
@@ -3,37 +3,55 @@
 
 """pytest fixtures for the fastapi unit test."""
 
-import os
 import pathlib
-import sys
 import typing
+from unittest import mock
 
 import pytest
-from ops.testing import Harness
+from ops import testing
 
 from examples.fastapi.charm.src.charm import FastAPICharm
+from paas_charm.paas_config import PaasConfig, read_paas_config
+
+from .constants import DEFAULT_LAYER
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent.parent
-_TEMPLATES_DIR = PROJECT_ROOT / "src" / "paas_charm" / "templates" / "fastapi"
-
-if str(_TEMPLATES_DIR) not in sys.path:
-    sys.path.insert(0, str(_TEMPLATES_DIR))
+FASTAPI_CHARM_ROOT = PROJECT_ROOT / "examples/fastapi/charm"
 
 
-@pytest.fixture(autouse=True, scope="package")
-def cwd():
-    return os.chdir(PROJECT_ROOT / "examples/fastapi/charm")
+@pytest.fixture(name="fastapi_context")
+def fastapi_context_fixture(
+    request: pytest.FixtureRequest,
+) -> typing.Generator[testing.Context[FastAPICharm], None, None]:
+    """Context rooted at the FastAPI example charm."""
+    paas_config = typing.cast(PaasConfig | None, getattr(request, "param", None))
+    if paas_config is None:
+        paas_config = read_paas_config(FASTAPI_CHARM_ROOT)
+    with (
+        mock.patch("paas_charm.charm.read_paas_config", return_value=paas_config),
+        testing.Context(FastAPICharm, charm_root=FASTAPI_CHARM_ROOT) as context,
+    ):
+        yield context
 
 
-@pytest.fixture(name="harness")
-def harness_fixture(container_name: str) -> typing.Generator[Harness, None, None]:
-    """Ops testing framework harness fixture."""
-    harness = Harness(FastAPICharm)
-    harness.set_leader()
-    root = harness.get_filesystem_root(container_name)
-    (root / "app").mkdir(parents=True)
-    harness.set_can_connect(container_name, True)
-    harness.update_config({"non-optional-string": "non-optional-value"})
-
-    yield harness
-    harness.cleanup()
+@pytest.fixture(name="base_state")
+def base_state_fixture():
+    """State with the FastAPI container and secret storage relation."""
+    return {
+        "leader": True,
+        "relations": [
+            testing.PeerRelation(
+                "secret-storage",
+                local_app_data={"fastapi_secret_key": "test"},
+            )
+        ],
+        "containers": {
+            testing.Container(
+                name="app",
+                can_connect=True,
+                _base_plan=DEFAULT_LAYER,
+            )
+        },
+        "model": testing.Model(name="test-model"),
+        "config": {"non-optional-string": "non-optional-value"},
+    }

--- a/tests/unit/fastapi/test_charm.py
+++ b/tests/unit/fastapi/test_charm.py
@@ -3,16 +3,10 @@
 
 """FastAPI charm unit tests."""
 
-# this is a unit test file
-# pylint: disable=protected-access
+import json
 
-import unittest
-
-import ops
 import pytest
-from ops.testing import Harness
-
-from .constants import DEFAULT_LAYER
+from ops import testing
 
 
 @pytest.mark.parametrize(
@@ -29,7 +23,7 @@ from .constants import DEFAULT_LAYER
                 "UVICORN_HOST": "0.0.0.0",
                 "METRICS_PORT": "8080",
                 "METRICS_PATH": "/metrics",
-                "APP_BASE_URL": "http://fastapi-k8s.None:8080",
+                "APP_BASE_URL": "http://fastapi-k8s.test-model:8080",
                 "APP_SECRET_KEY": "test",
                 "APP_OIDC_REDIRECT_PATH": "/callback",
                 "APP_OIDC_SCOPES": "openid profile email",
@@ -57,7 +51,7 @@ from .constants import DEFAULT_LAYER
                 "UVICORN_HOST": "0.0.0.0",
                 "METRICS_PORT": "8080",
                 "METRICS_PATH": "/metrics",
-                "APP_BASE_URL": "http://fastapi-k8s.None:8080",
+                "APP_BASE_URL": "http://fastapi-k8s.test-model:8080",
                 "APP_SECRET_KEY": "foobar",
                 "APP_USER_DEFINED_CONFIG": "userdefined",
                 # pylint: disable=line-too-long
@@ -83,25 +77,32 @@ from .constants import DEFAULT_LAYER
     ],
 )
 def test_fastapi_config(
-    harness: Harness, container_name: str, config: dict, postgresql_relation_data: dict, env: dict
+    fastapi_context,
+    base_state,
+    config: dict,
+    postgresql_relation_data: dict,
+    env: dict,
 ) -> None:
     """
     arrange: prepare the charm optionally with the postgresql relation.
     act: start the fastapi charm update the config options.
     assert: fastapi charm should submit the correct fastapi pebble layer to pebble.
     """
-    container = harness.model.unit.get_container(container_name)
-    container.add_layer("a_layer", DEFAULT_LAYER)
     if postgresql_relation_data:
-        harness.add_relation("postgresql", "postgresql-k8s", app_data=postgresql_relation_data)
+        base_state["relations"].append(
+            testing.Relation(
+                endpoint="postgresql",
+                interface="postgresql_client",
+                remote_app_data=postgresql_relation_data,
+            )
+        )
+    base_state["config"].update(config)
+    state = testing.State(**base_state)
 
-    harness.begin_with_initial_hooks()
-    harness.charm._secret_storage.get_secret_key = unittest.mock.MagicMock(return_value="test")
-    harness.update_config(config)
+    state_out = fastapi_context.run(fastapi_context.on.config_changed(), state)
 
-    assert harness.model.unit.status == ops.ActiveStatus()
-    plan = container.get_plan()
-    fastapi_layer = plan.to_dict()["services"]["fastapi"]
+    assert state_out.unit_status == testing.ActiveStatus()
+    fastapi_layer = state_out.get_container("app").plan.services["fastapi"].to_dict()
     assert fastapi_layer == {
         "environment": env,
         "override": "replace",
@@ -110,3 +111,32 @@ def test_fastapi_config(
         "user": "_daemon_",
         "working-dir": "/app",
     }
+
+
+def test_metrics_config(fastapi_context, base_state) -> None:
+    """
+    arrange: add a Prometheus scrape relation to the FastAPI state.
+    act: start the charm with a config-changed event.
+    assert: relation data contains the FastAPI unit and configured workload endpoint.
+    """
+    base_state["relations"].append(
+        testing.Relation(
+            endpoint="metrics-endpoint",
+            interface="prometheus_scrape",
+        )
+    )
+    state = testing.State(**base_state)
+
+    state_out = fastapi_context.run(fastapi_context.on.config_changed(), state)
+
+    assert state_out.unit_status == testing.ActiveStatus()
+    metrics_relations = state_out.get_relations("metrics-endpoint")
+    assert len(metrics_relations) == 1
+    assert metrics_relations[0].local_unit_data["prometheus_scrape_unit_address"]
+    assert metrics_relations[0].local_unit_data["prometheus_scrape_unit_name"] == "fastapi-k8s/0"
+    assert json.loads(metrics_relations[0].local_app_data["scrape_jobs"]) == [
+        {
+            "metrics_path": "/metrics",
+            "static_configs": [{"targets": ["*:8080"]}],
+        }
+    ]

--- a/tests/unit/fastapi/test_fastapi_app.py
+++ b/tests/unit/fastapi/test_fastapi_app.py
@@ -3,62 +3,37 @@
 
 """Scenario-style unit tests for FastAPIApp structured logging integration."""
 
-import pathlib
-
 import pytest
-from ops import pebble, testing
+from ops import testing
 
-from examples.fastapi.charm.src.charm import FastAPICharm
-from paas_charm.paas_config import LoggingFormat
-
-from .constants import DEFAULT_LAYER
+from paas_charm.paas_config import LoggingFormat, PaasConfig
 
 _LOG_CONFIG_DIR = "/tmp/fastapi/log_config"
 _HANDLER_FILE = "uvicorn_log_handler.py"
 _CONFIG_FILE = "uvicorn-log-config.json"
 
 
-@pytest.fixture(scope="function", name="base_state")
-def base_state_fixture(container_name: str) -> testing.State:
-    """Return a minimal State with the app container connected and peer relation initialised."""
-    container = testing.Container(
-        name=container_name,
-        can_connect=True,
-        layers={"base": pebble.Layer(DEFAULT_LAYER)},
-        service_statuses={"fastapi": pebble.ServiceStatus.INACTIVE},
-    )
-    peer_rel = testing.PeerRelation(
-        "secret-storage",
-        local_app_data={"fastapi_secret_key": "test-secret-key"},
-    )
-    return testing.State(
-        containers=[container],
-        relations=[peer_rel],
-        leader=True,
-        config={"non-optional-string": "test-value"},
-    )
-
-
 @pytest.mark.parametrize(
-    "logging_format, expected, absent",
+    "fastapi_context, expected, absent",
     [
         pytest.param(
-            LoggingFormat.NONE, [], ["UVICORN_LOG_CONFIG", "PYTHONPATH"], id="no-json-logging"
+            PaasConfig(framework_logging_format=LoggingFormat.NONE),
+            [],
+            ["UVICORN_LOG_CONFIG", "PYTHONPATH"],
+            id="no-json-logging",
         ),
         pytest.param(
-            LoggingFormat.JSON,
+            PaasConfig(framework_logging_format=LoggingFormat.JSON),
             ["UVICORN_LOG_CONFIG", "PYTHONPATH"],
             [],
             id="json-logging-enabled",
         ),
     ],
+    indirect=["fastapi_context"],
 )
 def test_fastapi_logging_environment(
-    base_state: testing.State,
-    container_name: str,
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: pathlib.Path,
-    logging_format: LoggingFormat,
+    fastapi_context,
+    base_state,
     expected: list[str],
     absent: list[str],
 ) -> None:
@@ -67,17 +42,14 @@ def test_fastapi_logging_environment(
     act: run pebble-ready.
     assert: UVICORN_LOG_CONFIG / PYTHONPATH are present (or absent) as expected.
     """
-    monkeypatch.chdir(tmp_path)
-    if logging_format != LoggingFormat.NONE:
-        (tmp_path / "paas-config.yaml").write_text(
-            f"framework_logging_format: {logging_format.value}\n", encoding="utf-8"
-        )
+    state = testing.State(**base_state)
+    container = state.get_container("app")
+    state_out = fastapi_context.run(
+        fastapi_context.on.pebble_ready(container=container),
+        state,
+    )
 
-    ctx = testing.Context(FastAPICharm)
-    container = base_state.get_container(container_name)
-    state_out = ctx.run(ctx.on.pebble_ready(container=container), base_state)
-
-    plan = state_out.get_container(container_name).plan
+    plan = state_out.get_container("app").plan
     env = plan.services["fastapi"].environment if plan and "fastapi" in plan.services else {}
 
     for key in expected:
@@ -85,58 +57,58 @@ def test_fastapi_logging_environment(
     for key in absent:
         assert key not in env, f"Unexpected env var {key!r} present"
 
-    if logging_format == LoggingFormat.JSON:
+    if "UVICORN_LOG_CONFIG" in expected:
         assert env["UVICORN_LOG_CONFIG"] == f"{_LOG_CONFIG_DIR}/{_CONFIG_FILE}"
         assert env["PYTHONPATH"].startswith(_LOG_CONFIG_DIR)
 
 
 def test_fastapi_json_logging_files_pushed(
-    base_state: testing.State,
-    container_name: str,
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: pathlib.Path,
+    fastapi_context,
+    base_state,
 ) -> None:
     """
-    arrange: set framework_logging_format=json.
+    arrange: use the real FastAPI paas-config with framework_logging_format=json.
     act: run pebble-ready.
     assert: formatter and log-config files are pushed to /tmp/fastapi/log_config/ in the container.
     """
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "paas-config.yaml").write_text(
-        "framework_logging_format: json\n", encoding="utf-8"
+    state = testing.State(**base_state)
+    container = state.get_container("app")
+    state_out = fastapi_context.run(
+        fastapi_context.on.pebble_ready(container=container),
+        state,
     )
 
-    ctx = testing.Context(FastAPICharm)
-    container = base_state.get_container(container_name)
-    state_out = ctx.run(ctx.on.pebble_ready(container=container), base_state)
-
-    container_out = state_out.get_container(container_name)
-    fs = container_out.get_filesystem(ctx)
+    container_out = state_out.get_container("app")
+    fs = container_out.get_filesystem(fastapi_context)
     assert (
         fs / _LOG_CONFIG_DIR.lstrip("/") / _HANDLER_FILE
     ).exists(), f"{_HANDLER_FILE} not pushed"
     assert (fs / _LOG_CONFIG_DIR.lstrip("/") / _CONFIG_FILE).exists(), f"{_CONFIG_FILE} not pushed"
 
 
+@pytest.mark.parametrize(
+    "fastapi_context",
+    [PaasConfig(framework_logging_format=LoggingFormat.NONE)],
+    indirect=True,
+)
 def test_fastapi_no_files_pushed_without_json_logging(
-    base_state: testing.State,
-    container_name: str,
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: pathlib.Path,
+    fastapi_context,
+    base_state,
 ) -> None:
     """
     arrange: no framework_logging_format set (default).
     act: run pebble-ready.
     assert: /tmp/fastapi/log_config/ is not created in the container.
     """
-    monkeypatch.chdir(tmp_path)
+    state = testing.State(**base_state)
+    container = state.get_container("app")
+    state_out = fastapi_context.run(
+        fastapi_context.on.pebble_ready(container=container),
+        state,
+    )
 
-    ctx = testing.Context(FastAPICharm)
-    container = base_state.get_container(container_name)
-    state_out = ctx.run(ctx.on.pebble_ready(container=container), base_state)
-
-    container_out = state_out.get_container(container_name)
-    fs = container_out.get_filesystem(ctx)
+    container_out = state_out.get_container("app")
+    fs = container_out.get_filesystem(fastapi_context)
     assert not (
         fs / _LOG_CONFIG_DIR.lstrip("/")
     ).exists(), "/tmp/fastapi/log_config should not be created"

--- a/tests/unit/fastapi/test_uvicorn_logging.py
+++ b/tests/unit/fastapi/test_uvicorn_logging.py
@@ -9,8 +9,10 @@ End-to-end verification (real Uvicorn + charm) is covered by the integration
 tests in ``tests/integration/fastapi/test_fastapi.py``.
 """
 
+import importlib.util
 import json
 import logging
+import pathlib
 import sys
 import unittest.mock
 
@@ -19,11 +21,24 @@ from opentelemetry import trace
 from opentelemetry.sdk.trace import (  # pylint: disable=import-error,no-name-in-module
     TracerProvider,
 )
-from uvicorn_log_handler import (  # pylint: disable=import-error
-    OtelCorrelationFilter,
-    UvicornJsonFormatter,
-    _span_context_var,
+
+_TEMPLATE_PATH = (
+    pathlib.Path(__file__).parents[3]
+    / "src"
+    / "paas_charm"
+    / "templates"
+    / "fastapi"
+    / "uvicorn_log_handler.py"
 )
+_MODULE_SPEC = importlib.util.spec_from_file_location("uvicorn_log_handler", _TEMPLATE_PATH)
+if _MODULE_SPEC is None or _MODULE_SPEC.loader is None:
+    raise ImportError(f"Unable to load {_TEMPLATE_PATH}")
+_MODULE = importlib.util.module_from_spec(_MODULE_SPEC)
+_MODULE_SPEC.loader.exec_module(_MODULE)
+
+OtelCorrelationFilter = _MODULE.OtelCorrelationFilter
+UvicornJsonFormatter = _MODULE.UvicornJsonFormatter
+_span_context_var = _MODULE._span_context_var
 
 trace.set_tracer_provider(TracerProvider())
 _TRACER = trace.get_tracer("test")


### PR DESCRIPTION
#### What this PR does

Migrates the FastAPI unit tests from the deprecated Harness API to `ops.testing.Context`. It adds a reusable charm-rooted Context fixture with deterministic lifecycle cleanup, realistic Scenario state for containers and relations, exact Pebble and metrics assertions, and shared coverage for structured logging and file pushes.

The tests now load the real FastAPI `paas-config.yaml` without changing the process working directory. The Uvicorn logging tests also load their template module explicitly instead of relying on package-wide `sys.path` mutation.

#### Why we need it

The FastAPI suite mixed Harness and Scenario APIs and depended on global cwd setup, making tests order-sensitive and preventing reliable execution outside the repository root. This aligns FastAPI with the Go and Spring Boot Scenario test patterns and preserves existing behavior coverage.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes (not applicable: test-only change)
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [x] **If I added or changed integration tests:** I updated the charm-ci configuration as needed (`spread.yaml` `integration-suites` and/or `artifacts.yaml`) (not applicable)
- [x] **If this is a Grafana dashboard:** I added a screenshot of the dashboard (not applicable)

#### Test plan

- Run all 13 FastAPI unit tests from the repository root.
- Run the same FastAPI suite from `/tmp` to verify charm-root independence.
- Run all 71 paas-config regression tests.
- Run focused isort, Black, codespell, and pylint checks for the touched files.

#### Review focus

Please focus on the shared `fastapi_context` fixture's real paas-config loading and indirect configuration overrides, plus the exact output-state assertions for PostgreSQL, metrics, structured logging, and pushed files.

#### Potential breaking changes

None. This changes test setup only and preserves the tested workload behavior.

#### Dependencies, APIs, modules, or workflow changes

No new dependencies or production APIs. FastAPI unit tests now consistently use the existing `ops.testing.Context` Scenario API.