### PR TITLE
Pin canonical/charm-ci to v1.0.0

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       packages: write
       actions: read
-    uses: canonical/charm-ci/.github/workflows/integration-test.yml@v0.0.1-alpha.10
+    uses: canonical/charm-ci/.github/workflows/integration-test.yml@0eef5b8cbef3ee74907850f790cab64bcf0499e5 # v1.0.0
     secrets: inherit
     with:
       charmcraft-channel: latest/edge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ where = ["src"]
 
 [tool.uv.sources]
 # opcli is published only from the charm-ci git repository, not PyPI.
-opcli = { git = "https://github.com/canonical/charm-ci.git", tag = "v0.0.1-alpha.10" }
+opcli = { git = "https://github.com/canonical/charm-ci.git", tag = "v1.0.0" }
 
 [tool.setuptools.package-data]
 paas_charm = ["**/cos/**", "**/cos/**/.**", "**/*.j2", "**/templates/**/*.py", "**/templates/**/*.json"]

--- a/renovate.json
+++ b/renovate.json
@@ -10,13 +10,32 @@
   ],
   "vulnerabilityAlerts": {
     "enabled": true,
-    "baseBranches": ["$default", "v1"]
+    "baseBranches": [
+      "$default",
+      "v1"
+    ]
   },
   "packageRules": [
     {
-      "matchFileNames": ["examples/**/charm/pyproject.toml"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "schedule": ["* * 1,15 * *"]
+      "matchFileNames": [
+        "examples/**/charm/pyproject.toml"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "schedule": [
+        "* * 1,15 * *"
+      ]
+    },
+    {
+      "groupName": "charm-ci",
+      "description": "Keep the opcli git dependency (pyproject.toml/uv.lock) and the canonical/charm-ci reusable workflow refs (.github/workflows) in lockstep, since they must always point at the same charm-ci release.",
+      "matchPackageNames": [
+        "opcli",
+        "canonical/charm-ci",
+        "*charm-ci*"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -10,23 +10,13 @@
   ],
   "vulnerabilityAlerts": {
     "enabled": true,
-    "baseBranches": [
-      "$default",
-      "v1"
-    ]
+    "baseBranches": ["$default", "v1"]
   },
   "packageRules": [
     {
-      "matchFileNames": [
-        "examples/**/charm/pyproject.toml"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "schedule": [
-        "* * 1,15 * *"
-      ]
+      "matchFileNames": ["examples/**/charm/pyproject.toml"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "schedule": ["* * 1,15 * *"]
     },
     {
       "groupName": "charm-ci",

--- a/uv.lock
+++ b/uv.lock
@@ -1676,8 +1676,8 @@ wheels = [
 
 [[package]]
 name = "opcli"
-version = "0.0.1a10"
-source = { git = "https://github.com/canonical/charm-ci.git?tag=v0.0.1-alpha.10#f0746f4dab15ea08354d38024b188b38576b944a" }
+version = "1.0.0"
+source = { git = "https://github.com/canonical/charm-ci.git?tag=v1.0.0#0eef5b8cbef3ee74907850f790cab64bcf0499e5" }
 dependencies = [
     { name = "pydantic" },
     { name = "ruamel-yaml" },
@@ -1835,7 +1835,7 @@ integration-tests = [
     { name = "juju", specifier = "==3.6.1.3" },
     { name = "lightkube", specifier = "==1.0.1" },
     { name = "minio", specifier = "==7.2.20" },
-    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?tag=v0.0.1-alpha.10" },
+    { name = "opcli", git = "https://github.com/canonical/charm-ci.git?tag=v1.0.0" },
     { name = "ops", specifier = "==3.8.1" },
     { name = "playwright", specifier = "==1.62.0" },
     { name = "pytest", specifier = ">=9.1.1" },


### PR DESCRIPTION
## Summary

- bump the existing `opcli` git source in `pyproject.toml` from `v0.0.1-alpha.10` to `v1.0.0`
- regenerate `uv.lock` so the resolved `opcli` commit matches charm-ci `v1.0.0`
- pin the reusable integration workflow to `0eef5b8cbef3ee74907850f790cab64bcf0499e5 # v1.0.0`
- add a Renovate package rule grouping `opcli` and `canonical/charm-ci` updates so they stay in lockstep

## Notes

This repo already uses `[tool.uv.sources]` correctly for `opcli`, so no dependency declaration migration was needed.

This is a CI/tooling-only change, so I did not update `docs/changelog.md`; I will apply the `no-release-note` label instead.

## Testing

- `uv lock`
- `python3 -c "import json; json.load(open('renovate.json'))"`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
